### PR TITLE
web: insert picture tag before dart js script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.1] - (2021-Mar-02)
+
+* Corrected location of `picture` tag in web to ensure that splash disappears.  Thanks [Dawid Dziurla](https://github.com/dawidd6).
+
 ## [0.3.0] - (2021-Feb-10)
 
 * Added support for web.  Closes [#30](https://github.com/jonbhanson/flutter_native_splash/issues/30).

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ First, add `flutter_native_splash` as a dev dependency in your pubspec.yaml file
 
 ```yaml
 dev_dependencies:
-  flutter_native_splash: ^0.3.0
+  flutter_native_splash: ^0.3.1
 ```
 
 Don't forget to `flutter pub get`.

--- a/lib/web.dart
+++ b/lib/web.dart
@@ -80,7 +80,7 @@ void updateIndex({String imageMode, bool showImages}) async {
 
   var foundExistingStyleSheet = false;
   var headCloseTagLine = 0;
-  var bodyCloseTagLine = 0;
+  var dartScriptTagLine = 0;
   var existingPictureLine = 0;
 
   final styleSheetLink =
@@ -92,8 +92,8 @@ void updateIndex({String imageMode, bool showImages}) async {
       foundExistingStyleSheet = true;
     } else if (line.contains('</head>')) {
       headCloseTagLine = x;
-    } else if (line.contains('</body>')) {
-      bodyCloseTagLine = x;
+    } else if (line.contains('src="main.dart.js"')) {
+      dartScriptTagLine = x;
     } else if (line.contains('<picture id="splash">')) {
       existingPictureLine = x;
     }
@@ -106,10 +106,10 @@ void updateIndex({String imageMode, bool showImages}) async {
   if (existingPictureLine == 0) {
     if (showImages) {
       for (var x = _indexHtmlPicture.length - 1; x >= 0; x--) {
-        lines[bodyCloseTagLine] =
+        lines[dartScriptTagLine] =
             _indexHtmlPicture[x].replaceFirst('[IMAGEMODE]', imageMode) +
                 '\n' +
-                lines[bodyCloseTagLine];
+                lines[dartScriptTagLine];
       }
     }
   } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_native_splash
 description: Generates native code to customize Flutter's default white native splash screen with background color and splash image. Supports dark mode, full screen, and more.
-version: 0.3.0
+version: 0.3.1
 homepage: https://github.com/jonbhanson/flutter_native_splash
 
 environment:


### PR DESCRIPTION
Without this, the splash screen stays on top after flutter app loads.

Currently the `picture` tag is inserted into `index.html` after the `main.dart.js` script. This causes the splash screen to always sit on top and never disappear. Instead insert the tag after script, which fixes the issue.