### PR TITLE
Fix Android dividers

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -11,21 +11,21 @@ class _AndroidDrawableTemplate {
 @visibleForTesting
 final List<_AndroidDrawableTemplate> androidSplashImages =
     <_AndroidDrawableTemplate>[
-  _AndroidDrawableTemplate(directoryName: 'drawable-mdpi', divider: 2.0),
-  _AndroidDrawableTemplate(directoryName: 'drawable-hdpi', divider: 1.8),
-  _AndroidDrawableTemplate(directoryName: 'drawable-xhdpi', divider: 1.4),
-  _AndroidDrawableTemplate(directoryName: 'drawable-xxhdpi', divider: 1.2),
+  _AndroidDrawableTemplate(directoryName: 'drawable-mdpi', divider: 4.0),
+  _AndroidDrawableTemplate(directoryName: 'drawable-hdpi', divider: 2.67),
+  _AndroidDrawableTemplate(directoryName: 'drawable-xhdpi', divider: 2.0),
+  _AndroidDrawableTemplate(directoryName: 'drawable-xxhdpi', divider: 1.33),
   _AndroidDrawableTemplate(directoryName: 'drawable-xxxhdpi', divider: 1.0),
 ];
 
 @visibleForTesting
 final List<_AndroidDrawableTemplate> androidSplashImagesDark =
     <_AndroidDrawableTemplate>[
-  _AndroidDrawableTemplate(directoryName: 'drawable-night-mdpi', divider: 2.0),
-  _AndroidDrawableTemplate(directoryName: 'drawable-night-hdpi', divider: 1.8),
-  _AndroidDrawableTemplate(directoryName: 'drawable-night-xhdpi', divider: 1.4),
+  _AndroidDrawableTemplate(directoryName: 'drawable-night-mdpi', divider: 4.0),
+  _AndroidDrawableTemplate(directoryName: 'drawable-night-hdpi', divider: 2.67),
+  _AndroidDrawableTemplate(directoryName: 'drawable-night-xhdpi', divider: 2.0),
   _AndroidDrawableTemplate(
-      directoryName: 'drawable-night-xxhdpi', divider: 1.2),
+      directoryName: 'drawable-night-xxhdpi', divider: 1.33),
   _AndroidDrawableTemplate(
       directoryName: 'drawable-night-xxxhdpi', divider: 1.0),
 ];


### PR DESCRIPTION
The dividers in Android are incorrect and therefore produce overly large images on phones with pixel densities less than xxxhdpi.

They were set to:
mdpi: 2.0
hdpi: 1.8
xhdpi: 1.4
xxhdpi: 1.2
xxxhdpi: 1.0

This can be reproduced with any size image, but for example I used a 1152x300 image which looked fine on xxxhdpi, but where you could only see the middle of the image on an mdpi phone.

The values should be:
mdpi: 4.0
hdpi: 2.67
xhdpi: 2.0
xxhdpi: 1.33
xxxhdpi: 1.0

This fix makes those changes.