### PR TITLE
Add Command Line Path To Config File

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ flutter pub run flutter_native_splash:create
 
 When the package finishes running, your splash screen is ready.
 
-For different flavors or to specify the yaml file location, just add the following path with the command 
+To specify the yaml file location just add --path with the command in the terminal:
 
 ```
 flutter pub run flutter_native_splash:create --path=path/to/my/file.yaml

--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ flutter pub run flutter_native_splash:create
 
 When the package finishes running, your splash screen is ready.
 
+For different flavors or to specify the yaml file location, just add the following path with the command 
+
+```
+flutter pub run flutter_native_splash:create --path=path/to/my/file.yaml
+```
+
 # Recommendations
 ## Secondary splash screen:
 The native splash screen is displayed while the native app loads the Flutter framework. Once Flutter loads, there may still be resources that need to be loaded before your app is ready.  For this reason, you should consider implementing a Flutter splash screen that is displayed while these resources load.  Here is a code example of a secondary Flutter splash screen, or use a package from [pub.dev](https://pub.dev).

--- a/bin/create.dart
+++ b/bin/create.dart
@@ -1,6 +1,10 @@
+import 'package:args/args.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart'
     as flutter_native_splash;
 
-void main(List<String> arguments) {
-  flutter_native_splash.createSplash();
+void main(List<String> args) {
+  var parser = ArgParser();
+  parser.addOption('path',
+      callback: (path) => {flutter_native_splash.createSplash(path)});
+  parser.parse(args);
 }

--- a/bin/remove.dart
+++ b/bin/remove.dart
@@ -1,6 +1,10 @@
+import 'package:args/args.dart';
 import 'package:flutter_native_splash/flutter_native_splash.dart'
     as flutter_native_splash;
 
-void main(List<String> arguments) {
-  flutter_native_splash.removeSplash();
+void main(List<String> args) {
+  var parser = ArgParser();
+  parser.addOption('path',
+      callback: (path) => {flutter_native_splash.removeSplash(path)});
+  parser.parse(args);
 }

--- a/lib/flutter_native_splash.dart
+++ b/lib/flutter_native_splash.dart
@@ -16,8 +16,8 @@ part 'templates.dart';
 part 'web.dart';
 
 /// Create splash screens for Android and iOS
-void createSplash() {
-  var config = getConfig();
+void createSplash(String? path) {
+  var config = getConfig(configFile: path);
   checkConfig(config);
   createSplashByConfig(config);
 }
@@ -83,9 +83,9 @@ void createSplashByConfig(Map<String, dynamic> config) {
 }
 
 /// Remove any splash screen by setting the default white splash
-void removeSplash() {
+void removeSplash(String? path) {
   print('Restoring Flutter\'s default white native splash screen...');
-  var config = getConfig();
+  var config = getConfig(configFile: path);
 
   var removeConfig = <String, dynamic>{'color': '#ffffff'};
   if (config.containsKey('android')) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
+  args: ^2.1.1
   image: ^3.0.2
   meta: ^1.3.0
   path: ^1.8.0


### PR DESCRIPTION
- Pass "--path=path/to/file.yaml" , i.e 
```
flutter pub run flutter_native_splash:create --path=path/to/file.yaml
```
- If no path specified, still goes to current defaults 
- Used args.dart as a simple way to parse args to configFile function
- Feature Request on https://github.com/jonbhanson/flutter_native_splash/issues/160

Tested with branch by updating pubspec.yaml to 
```
  flutter_native_splash:
    git: 
      url: https://github.com/lyledean1/flutter_native_splash
      ref: add-flavour
```