### PR TITLE
feat: choose between icon and image on android 12 splash

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,13 @@ flutter_native_splash:
   #ios: false
   #web: false
 
+  # The mode to use for android 12 splash screen. The default behavior is to use the app's icon as
+  # the splash image, but we can customize that so we use the same asset that was provided to the
+  # image/image_dark parameter.
+  # Please note that the splash screen will be clipped to a circle on the center of the screen.
+  # More info https://developer.android.com/guide/topics/ui/splash-screen#splash_screen_dimensions
+  #android_12_mode: 'use_image'
+
   # The position of the splash image can be set with android_gravity, ios_content_mode, and
   # web_image_mode parameters.  All default to center.
   #
@@ -158,7 +165,7 @@ If you find this package useful, you can support it for free by giving it a thum
 
 # Android 12 Support
 
-Android 12 has a [new method](https://developer.android.com/about/versions/12/features/splash-screen) of adding splash screens, which consists of a window background, icon, and the icon background.  This package supports setting the background color and the icon is taken from the launcher icon.
+Android 12 has a [new method](https://developer.android.com/about/versions/12/features/splash-screen) of adding splash screens, which consists of a window background, icon, and the icon background.  This package supports setting the background color and gives you the options to use the launcher icon or use the provided splash image with the `android_12_mode` configuration option.
 
 The package will add a `styles.xml` in `values-v31` and `values-night-v31` resource folders, which will provide Android 12 support while maintaining the legacy splash screen for previous versions of Android.
 

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -46,6 +46,7 @@ void _createAndroidSplash({
   required bool fullscreen,
   required String? backgroundImage,
   required String? darkBackgroundImage,
+  required String? android12Mode,
 }) {
   if (imagePath != null) {
     _applyImageAndroid(imagePath: imagePath);
@@ -130,27 +131,27 @@ void _createAndroidSplash({
       fullScreen: fullscreen,
       file: _androidV31StylesFile,
       template: _androidV31StylesXml,
-      android12BackgroundColor: color);
+      android12BackgroundColor: color,
+      android12Mode: android12Mode);
   if (darkColor != null) {
     _applyStylesXml(
         fullScreen: fullscreen,
         file: _androidV31StylesNightFile,
         template: _androidV31StylesNightXml,
-        android12BackgroundColor: darkColor);
+        android12BackgroundColor: darkColor,
+        android12Mode: android12Mode);
   }
 
   _applyStylesXml(
       fullScreen: fullscreen,
       file: _androidStylesFile,
-      template: _androidStylesXml,
-      android12BackgroundColor: null);
+      template: _androidStylesXml);
 
   if (darkColor != null || darkBackgroundImage != null) {
     _applyStylesXml(
         fullScreen: fullscreen,
         file: _androidNightStylesFile,
-        template: _androidStylesNightXml,
-        android12BackgroundColor: null);
+        template: _androidStylesNightXml);
   }
 }
 
@@ -245,7 +246,8 @@ void _applyStylesXml(
     {required bool fullScreen,
     required String file,
     required String template,
-    required String? android12BackgroundColor}) {
+    String? android12BackgroundColor,
+    String? android12Mode}) {
   final stylesFile = File(file);
   print('[Android]    - ' + file);
   if (!stylesFile.existsSync()) {
@@ -258,14 +260,16 @@ void _applyStylesXml(
   _updateStylesFile(
       fullScreen: fullScreen,
       stylesFile: stylesFile,
-      android12BackgroundColor: android12BackgroundColor);
+      android12BackgroundColor: android12BackgroundColor,
+      android12Mode: android12Mode);
 }
 
 /// Updates styles.xml adding full screen property
 Future<void> _updateStylesFile(
     {required bool fullScreen,
     required File stylesFile,
-    required String? android12BackgroundColor}) async {
+    required String? android12BackgroundColor,
+    required String? android12Mode}) async {
   final stylesDocument = XmlDocument.parse(stylesFile.readAsStringSync());
   final resources = stylesDocument.getElement('resources');
   final styles = resources?.findElements('style');
@@ -304,6 +308,13 @@ Future<void> _updateStylesFile(
         launchTheme: launchTheme,
         name: 'android:windowSplashScreenBackground',
         value: '#' + android12BackgroundColor);
+  }
+
+  if (android12Mode == 'use_image') {
+    replaceElement(
+        launchTheme: launchTheme,
+        name: 'android:windowSplashScreenAnimatedIcon',
+        value: '@drawable/splash');
   }
 
   stylesFile.writeAsStringSync(

--- a/lib/cli_commands.dart
+++ b/lib/cli_commands.dart
@@ -46,6 +46,8 @@ void createSplashByConfig(Map<String, dynamic> config) {
   String iosContentMode = config['ios_content_mode'] ?? 'center';
   final webImageMode = (config['web_image_mode'] ?? 'center');
 
+  final android12Mode = (config['android_12_mode'] ?? 'use_app_icon');
+
   if (!config.containsKey('android') || config['android']) {
     if (Directory('android').existsSync()) {
       _createAndroidSplash(
@@ -60,6 +62,7 @@ void createSplashByConfig(Map<String, dynamic> config) {
         gravity: gravity,
         brandingGravity: brandingGravity,
         fullscreen: fullscreen,
+        android12Mode: android12Mode,
       );
     } else {
       print('Android folder not found, skipping Android splash update...');


### PR DESCRIPTION
- Add behaviour to choose between using the App's default icon or the provided splash screen image.
- Documentation for new property

Fixes #293