### PR TITLE
Fix unhandled exception when branding not set

### DIFF
--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -85,7 +85,9 @@ void _createiOSSplash({
         list: iOSBrandingImages,
         targetPath: _iOSAssetsBrandingImageFolder);
   } else {
-    Directory(_iOSAssetsBrandingImageFolder).delete(recursive: true);
+    if (Directory(_iOSAssetsBrandingImageFolder).existsSync()) {
+      Directory(_iOSAssetsBrandingImageFolder).delete(recursive: true);
+    }
   }
   if (brandingDarkImagePath != null) {
     _applyImageiOS(


### PR DESCRIPTION
The latest release `2.1.2` throws an unhandled Exception when trying to delete a non existent `BrandingImage.imageset` directory.
See the screenshot below with the output of the CLI:   

<img width="694" alt="Screen Shot 2022-03-28 at 9 44 46 AM" src="https://user-images.githubusercontent.com/1177483/160300448-d6f8bcae-5aff-48e1-819c-a8f354adf84d.png">

