### PR TITLE
Fix androidV31StylesXml not being generated when darkBackgroundImage is set

### DIFF
--- a/lib/android.dart
+++ b/lib/android.dart
@@ -168,7 +168,7 @@ void _createAndroidSplash({
     android12BrandingImagePath: brandingImagePath,
   );
 
-  if (darkColor != null) {
+  if (darkColor != null || darkBackgroundImage != null) {
     _applyStylesXml(
       fullScreen: fullscreen,
       file: _androidV31StylesNightFile,


### PR DESCRIPTION
It was only generated in case darkColor was set.