### PR TITLE
Branding Image support for the web platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,314 +1,349 @@
 ## [2.2.4] - (2022-July-03)
-* Added parameters for platform-specific images.  Closes [#375](https://github.com/jonbhanson/flutter_native_splash/issues/375).
-* Remove black status bar which appeared on Android devices with a notch.  Fixes [#311](https://github.com/jonbhanson/flutter_native_splash/issues/311).
+
+- Added parameters for platform-specific images. Closes [#375](https://github.com/jonbhanson/flutter_native_splash/issues/375).
+- Remove black status bar which appeared on Android devices with a notch. Fixes [#311](https://github.com/jonbhanson/flutter_native_splash/issues/311).
+
 ## [2.2.3+1] - (2022-June-12)
-* Updated readme.
+
+- Updated readme.
+
 ## [2.2.3] - (2022-June-5)
-* Create new storyboard file rather than try to modify existing file.  Closes [#369](https://github.com/jonbhanson/flutter_native_splash/issues/369).
-* Reverted 2.1.6 change of using light settings for dark mode if omitted.  Fixes [#368](https://github.com/jonbhanson/flutter_native_splash/issues/368).
+
+- Create new storyboard file rather than try to modify existing file. Closes [#369](https://github.com/jonbhanson/flutter_native_splash/issues/369).
+- Reverted 2.1.6 change of using light settings for dark mode if omitted. Fixes [#368](https://github.com/jonbhanson/flutter_native_splash/issues/368).
+
 ## [2.2.2] - (2022-May-29)
-* Corrected Android 12 color overriding color parameter.  Closes [#365](https://github.com/jonbhanson/flutter_native_splash/issues/365).
-* Add support for setting screen orientation in Android.  Closes [#344](https://github.com/jonbhanson/flutter_native_splash/issues/344).
+
+- Corrected Android 12 color overriding color parameter. Closes [#365](https://github.com/jonbhanson/flutter_native_splash/issues/365).
+- Add support for setting screen orientation in Android. Closes [#344](https://github.com/jonbhanson/flutter_native_splash/issues/344).
+
 ## [2.2.1] - (2022-May-22)
-* Updated dependencies.  Closes [#358](https://github.com/jonbhanson/flutter_native_splash/issues/358).
-* Added Android 12 background color support.  Closes [#357](https://github.com/jonbhanson/flutter_native_splash/issues/357).
-* Resolve exception that occurs when using remove command.  Closes [#355](https://github.com/jonbhanson/flutter_native_splash/issues/355).
+
+- Updated dependencies. Closes [#358](https://github.com/jonbhanson/flutter_native_splash/issues/358).
+- Added Android 12 background color support. Closes [#357](https://github.com/jonbhanson/flutter_native_splash/issues/357).
+- Resolve exception that occurs when using remove command. Closes [#355](https://github.com/jonbhanson/flutter_native_splash/issues/355).
+
 ## [2.2.0+1] - (2022-May-15)
-* Added flavor support.  Thanks [Vladimir](https://github.com/vlazdra) for PR [#316](https://github.com/jonbhanson/flutter_native_splash/pull/316)!  Closes [#160](https://github.com/jonbhanson/flutter_native_splash/issues/160).
-* Fix androidV31StylesXml not being generated when darkBackgroundImage is set.  Thanks (Hallot)[https://github.com/Hallot] for PR [#349](https://github.com/jonbhanson/flutter_native_splash/pull/349).
-* Fix incorrect android_12 check for image_dark.  Closes [#347](https://github.com/jonbhanson/flutter_native_splash/issues/347).
-* Fix Flutter v3 WidgetsBinding.Instance! Null check warning. Closes [#351](https://github.com/jonbhanson/flutter_native_splash/issues/351).
+
+- Added flavor support. Thanks [Vladimir](https://github.com/vlazdra) for PR [#316](https://github.com/jonbhanson/flutter_native_splash/pull/316)! Closes [#160](https://github.com/jonbhanson/flutter_native_splash/issues/160).
+- Fix androidV31StylesXml not being generated when darkBackgroundImage is set. Thanks (Hallot)[https://github.com/Hallot] for PR [#349](https://github.com/jonbhanson/flutter_native_splash/pull/349).
+- Fix incorrect android_12 check for image_dark. Closes [#347](https://github.com/jonbhanson/flutter_native_splash/issues/347).
+- Fix Flutter v3 WidgetsBinding.Instance! Null check warning. Closes [#351](https://github.com/jonbhanson/flutter_native_splash/issues/351).
+
 ## [2.1.6] - (2022-Apr-17)
-* Use light settings for dark mode if dark mode settings are omitted.
-* Add ALT tag for web.  Fixes [#339](https://github.com/jonbhanson/flutter_native_splash/issues/339).
+
+- Use light settings for dark mode if dark mode settings are omitted.
+- Add ALT tag for web. Fixes [#339](https://github.com/jonbhanson/flutter_native_splash/issues/339).
+
 ## [2.1.5] - (2022-Apr-10)
-* Thanks [Yousef](https://github.com/YDA93) for [PR #332](https://github.com/jonbhanson/flutter_native_splash/pull/332) adding stricter lint rules and [zuboje](https://github.com/zuboje) for [PR #334](https://github.com/jonbhanson/flutter_native_splash/pull/334) adding deprecated message.
+
+- Thanks [Yousef](https://github.com/YDA93) for [PR #332](https://github.com/jonbhanson/flutter_native_splash/pull/332) adding stricter lint rules and [zuboje](https://github.com/zuboje) for [PR #334](https://github.com/jonbhanson/flutter_native_splash/pull/334) adding deprecated message.
+
 ## [2.1.3+1] - (2022-Apr-03)
-* Updated documentation. Closes [#327](https://github.com/jonbhanson/flutter_native_splash/issues/327). 
-* `remove` correctly handles multiple plist files.  Fixes [#247](https://github.com/jonbhanson/flutter_native_splash/issues/247).
+
+- Updated documentation. Closes [#327](https://github.com/jonbhanson/flutter_native_splash/issues/327).
+- `remove` correctly handles multiple plist files. Fixes [#247](https://github.com/jonbhanson/flutter_native_splash/issues/247).
+
 ## [2.1.2+1] - (2022-Mar-27)
-* Add branding support in Android 12.  Thanks [Vladimir](https://github.com/vlazdra) for the [PR](https://github.com/jonbhanson/flutter_native_splash/pull/316).
-* Updated readme.  Closes [#317](https://github.com/jonbhanson/flutter_native_splash/issues/317).  Closes [#318](https://github.com/jonbhanson/flutter_native_splash/issues/318).
-* Don't create a blank branding imageset.  Fixes [#264](https://github.com/jonbhanson/flutter_native_splash/issues/264).
+
+- Add branding support in Android 12. Thanks [Vladimir](https://github.com/vlazdra) for the [PR](https://github.com/jonbhanson/flutter_native_splash/pull/316).
+- Updated readme. Closes [#317](https://github.com/jonbhanson/flutter_native_splash/issues/317). Closes [#318](https://github.com/jonbhanson/flutter_native_splash/issues/318).
+- Don't create a blank branding imageset. Fixes [#264](https://github.com/jonbhanson/flutter_native_splash/issues/264).
+
 ## [2.1.1] - (2022-Mar-13)
-* Fix for pixelated splash image on web.  Fixes [#263](https://github.com/jonbhanson/flutter_native_splash/issues/263).
+
+- Fix for pixelated splash image on web. Fixes [#263](https://github.com/jonbhanson/flutter_native_splash/issues/263).
+
 ## [2.1.0] - (2022-Mar-06)
-* Expanded options for Android 12.  Thanks [Jose](https://github.com/JCQuintas) for the [PR](https://github.com/jonbhanson/flutter_native_splash/pull/300) that served as a good starting point.
+
+- Expanded options for Android 12. Thanks [Jose](https://github.com/JCQuintas) for the [PR](https://github.com/jonbhanson/flutter_native_splash/pull/300) that served as a good starting point.
+
 ## [2.0.5] - (2022-Feb-20)
-* Converted to a plugin since there is now platform specific code.
+
+- Converted to a plugin since there is now platform specific code.
+
 ## [2.0.4] - (2022-Feb-15)
-* Fix Error: Not found: 'dart:js' error.  Fixes [#292](https://github.com/jonbhanson/flutter_native_splash/issues/292).
+
+- Fix Error: Not found: 'dart:js' error. Fixes [#292](https://github.com/jonbhanson/flutter_native_splash/issues/292).
 
 ## [2.0.3+1] - (2022-Feb-14)
-* Added preserve() and remove() methods.
-* Remove splash from DOM in web.
+
+- Added preserve() and remove() methods.
+- Remove splash from DOM in web.
 
 ## [2.0.2] - (2022-Feb-07)
-* Update existing styles xml to support Xiaomi/Redmi devices.  Fixes [#285](https://github.com/jonbhanson/flutter_native_splash/issues/285), fixes [#281](https://github.com/jonbhanson/flutter_native_splash/issues/281).
-* Avoid changing logo size on mobile browsers.  Fixes [#276](https://github.com/jonbhanson/flutter_native_splash/issues/276).
+
+- Update existing styles xml to support Xiaomi/Redmi devices. Fixes [#285](https://github.com/jonbhanson/flutter_native_splash/issues/285), fixes [#281](https://github.com/jonbhanson/flutter_native_splash/issues/281).
+- Avoid changing logo size on mobile browsers. Fixes [#276](https://github.com/jonbhanson/flutter_native_splash/issues/276).
 
 ## [2.0.1+1] - (2022-Jan-29)
-* Provide BuildContext argument to the initialization function.
+
+- Provide BuildContext argument to the initialization function.
 
 ## [2.0.0] - (2022-Jan-29)
-* BREAKING CHANGE: Added `removeAfter` method which allows the native splash to remain until an initialization routine is complete.  In order to use this method, the `flutter_native_splash` dependency must be moved from `dev_dependencies` to `dependencies`.  Thanks [Ahmed](https://github.com/Ahmed-gubara) for the tip.  Closes [#271](https://github.com/jonbhanson/flutter_native_splash/issues/271).
+
+- BREAKING CHANGE: Added `removeAfter` method which allows the native splash to remain until an initialization routine is complete. In order to use this method, the `flutter_native_splash` dependency must be moved from `dev_dependencies` to `dependencies`. Thanks [Ahmed](https://github.com/Ahmed-gubara) for the tip. Closes [#271](https://github.com/jonbhanson/flutter_native_splash/issues/271).
 
 ## [1.3.3] - (2022-Jan-01)
-* Merged PR that adds branding.  Thanks [Faiizii](https://github.com/Faiizii) for PR.  Closes [#256](https://github.com/jonbhanson/flutter_native_splash/issues/256).
-* Updated readme.  Closes [#258](https://github.com/jonbhanson/flutter_native_splash/issues/258).
-* Fix so that the splash screen does not cover the app in web.  Fixes [253](https://github.com/jonbhanson/flutter_native_splash/issues/253).
-* Updates per linter rules.
+
+- Merged PR that adds branding. Thanks [Faiizii](https://github.com/Faiizii) for PR. Closes [#256](https://github.com/jonbhanson/flutter_native_splash/issues/256).
+- Updated readme. Closes [#258](https://github.com/jonbhanson/flutter_native_splash/issues/258).
+- Fix so that the splash screen does not cover the app in web. Fixes [253](https://github.com/jonbhanson/flutter_native_splash/issues/253).
+- Updates per linter rules.
 
 ## [1.3.2] - (2021-Nov-28)
-* Updated readme.  Hide splash image in web from screen readers.  Closes [#231](https://github.com/jonbhanson/flutter_native_splash/issues/231).
+
+- Updated readme. Hide splash image in web from screen readers. Closes [#231](https://github.com/jonbhanson/flutter_native_splash/issues/231).
 
 ## [1.3.1] - (2021-Oct-27)
-* Don't create Android 12 night res files if dark mode is not configured.  Fixes [#227](https://github.com/jonbhanson/flutter_native_splash/issues/227).  `Remove` command takes dark mode into account.
+
+- Don't create Android 12 night res files if dark mode is not configured. Fixes [#227](https://github.com/jonbhanson/flutter_native_splash/issues/227). `Remove` command takes dark mode into account.
 
 ## [1.3.0] - (2021-Oct-26)
-* Added Android 12 support.  Closes [#204](https://github.com/jonbhanson/flutter_native_splash/issues/204), closes [#226](https://github.com/jonbhanson/flutter_native_splash/issues/226).
+
+- Added Android 12 support. Closes [#204](https://github.com/jonbhanson/flutter_native_splash/issues/204), closes [#226](https://github.com/jonbhanson/flutter_native_splash/issues/226).
 
 ## [1.2.4] - (2021-Sep-23)
-* Updated readme.  Thanks [@j-j-gajjar](https://github.com/j-j-gajjar) for PR [#216](https://github.com/jonbhanson/flutter_native_splash/pull/216).
-* Remove references to background images in web when images are missing.  Fixes [#196](https://github.com/jonbhanson/flutter_native_splash/issues/196).
-* Updated dependencies.
+
+- Updated readme. Thanks [@j-j-gajjar](https://github.com/j-j-gajjar) for PR [#216](https://github.com/jonbhanson/flutter_native_splash/pull/216).
+- Remove references to background images in web when images are missing. Fixes [#196](https://github.com/jonbhanson/flutter_native_splash/issues/196).
+- Updated dependencies.
 
 ## [1.2.3] - (2021-Sep-08)
-* Reverted XML dependency to be compatible with stable Flutter branch. Closes [#206](https://github.com/jonbhanson/flutter_native_splash/issues/206).
+
+- Reverted XML dependency to be compatible with stable Flutter branch. Closes [#206](https://github.com/jonbhanson/flutter_native_splash/issues/206).
 
 ## [1.2.2] - (2021-Sep-06)
 
-* Added a FAQ to address the deprecation of `SplashScreenDrawable`.  Closes [#199](https://github.com/jonbhanson/flutter_native_splash/issues/199).
-* Added `<picture>` tag to `index.html` by finding the `</body>` tag instead of `src="main.dart.js`, which was removed in Flutter 2.5.  Fixes [#202](https://github.com/jonbhanson/flutter_native_splash/issues/202).
-* Added `<item name="android:forceDarkAllowed">false</item>` tag to dark mode `styles.xml` to improve Xiaomi support.  Closes [#184](https://github.com/jonbhanson/flutter_native_splash/issues/184).
+- Added a FAQ to address the deprecation of `SplashScreenDrawable`. Closes [#199](https://github.com/jonbhanson/flutter_native_splash/issues/199).
+- Added `<picture>` tag to `index.html` by finding the `</body>` tag instead of `src="main.dart.js`, which was removed in Flutter 2.5. Fixes [#202](https://github.com/jonbhanson/flutter_native_splash/issues/202).
+- Added `<item name="android:forceDarkAllowed">false</item>` tag to dark mode `styles.xml` to improve Xiaomi support. Closes [#184](https://github.com/jonbhanson/flutter_native_splash/issues/184).
 
 ## [1.2.1] - (2021-Jul-19)
-* Check the file type and exit with error if it is not a PNG.
-* Updated documentation with more FAQs.
-* Fixed bug that was preventing copying of images for web.  Fixes [#192](https://github.com/jonbhanson/flutter_native_splash/issues/192).
-* Changed the example to show a secondary splash screen.
-* Check that android, web, and ios folders exist before updating respective splash screen.
+
+- Check the file type and exit with error if it is not a PNG.
+- Updated documentation with more FAQs.
+- Fixed bug that was preventing copying of images for web. Fixes [#192](https://github.com/jonbhanson/flutter_native_splash/issues/192).
+- Changed the example to show a secondary splash screen.
+- Check that android, web, and ios folders exist before updating respective splash screen.
 
 ## [1.2.0] - (2021-Jun-09)
 
-* Added beta support for Android 12.  Closes [#175](https://github.com/jonbhanson/flutter_native_splash/issues/175).
+- Added beta support for Android 12. Closes [#175](https://github.com/jonbhanson/flutter_native_splash/issues/175).
 
 ## [1.1.9] - (2021-Jun-09)
 
-* Added path argument to command line.  Thanks [@lyledean1](https://github.com/lyledean1) for PR [#180](https://github.com/jonbhanson/flutter_native_splash/pull/180).
+- Added path argument to command line. Thanks [@lyledean1](https://github.com/lyledean1) for PR [#180](https://github.com/jonbhanson/flutter_native_splash/pull/180).
 
 ## [1.1.8+4] - (2021-Apr-20)
 
-* Fixed bug that was preventing copying of dark background.  Fixes [#163](https://github.com/jonbhanson/flutter_native_splash/issues/163).
+- Fixed bug that was preventing copying of dark background. Fixes [#163](https://github.com/jonbhanson/flutter_native_splash/issues/163).
 
 ## [1.1.7+1] - (2021-Apr-02)
 
-* flutter_native_splash:remove adheres to android/ios/web setting.  Fixes [#159](https://github.com/jonbhanson/flutter_native_splash/issues/159).
-* Updated readme images.
+- flutter_native_splash:remove adheres to android/ios/web setting. Fixes [#159](https://github.com/jonbhanson/flutter_native_splash/issues/159).
+- Updated readme images.
 
 ## [1.1.6+1] - (2021-Mar-29)
 
-* Corrected Android scaling.  Thanks [@chris-efission](https://github.com/chris-efission).
-* Updated readme image.
+- Corrected Android scaling. Thanks [@chris-efission](https://github.com/chris-efission).
+- Updated readme image.
 
 ## [1.1.5+1] - (2021-Mar-23)
 
-* Added unit tests.
-* Updated dependency.
+- Added unit tests.
+- Updated dependency.
 
 ## [1.1.4+1] - (2021-Mar-18)
 
-* Fixed bug that created duplicate android:windowFullscreen tags in styles.xml. Closes [#147](https://github.com/jonbhanson/flutter_native_splash/issues/147).
-* Fixed fullscreen in Android dark mode.
-* Print errors instead of throwing exceptions for cleaner output.
-* Added message for missing subviews in iOS LaunchScreen.storyboard. Fixes [#146](https://github.com/jonbhanson/flutter_native_splash/issues/146).
-* Removed duplicate exceptions for missing image file since that is now checked at package start.
+- Fixed bug that created duplicate android:windowFullscreen tags in styles.xml. Closes [#147](https://github.com/jonbhanson/flutter_native_splash/issues/147).
+- Fixed fullscreen in Android dark mode.
+- Print errors instead of throwing exceptions for cleaner output.
+- Added message for missing subviews in iOS LaunchScreen.storyboard. Fixes [#146](https://github.com/jonbhanson/flutter_native_splash/issues/146).
+- Removed duplicate exceptions for missing image file since that is now checked at package start.
 
 ## [1.1.3] - (2021-Mar-18)
 
-* Fixed bug that was giving error on copying background image.  Closes [#144](https://github.com/jonbhanson/flutter_native_splash/issues/144).
+- Fixed bug that was giving error on copying background image. Closes [#144](https://github.com/jonbhanson/flutter_native_splash/issues/144).
 
 ## [1.1.2] - (2021-Mar-17)
 
-* Check that image files exist before starting.  Throw an exception if image file not found.
+- Check that image files exist before starting. Throw an exception if image file not found.
 
 ## [1.1.1+1] - (2021-Mar-16)
 
-* Create Styles.css before writing to it.  Closes [#141](https://github.com/jonbhanson/flutter_native_splash/issues/141)
-* Make all file calls synchronously to make code cleaner.
+- Create Styles.css before writing to it. Closes [#141](https://github.com/jonbhanson/flutter_native_splash/issues/141)
+- Make all file calls synchronously to make code cleaner.
 
 ## [1.1.0] - (2021-Mar-15)
 
-* Added option for background image.  Closes [#22](https://github.com/jonbhanson/flutter_native_splash/issues/22).
+- Added option for background image. Closes [#22](https://github.com/jonbhanson/flutter_native_splash/issues/22).
 
 ## [1.0.3] - (2021-Mar-05)
 
-* Updated readme.
+- Updated readme.
 
 ## [1.0.2] - (2021-Mar-04)
 
-* Added exception for missing/renamed splash image in LaunchScreen.storyboard.
+- Added exception for missing/renamed splash image in LaunchScreen.storyboard.
 
 ## [1.0.1+1] - (2021-Mar-02)
 
-* Corrected location of `picture` tag in web to ensure that splash disappears.  Thanks [Dawid Dziurla](https://github.com/dawidd6).
+- Corrected location of `picture` tag in web to ensure that splash disappears. Thanks [Dawid Dziurla](https://github.com/dawidd6).
 
 ## [1.0.0] - (2021-Feb-19)
 
-* Adds null safety.  Closes [#127](https://github.com/jonbhanson/flutter_native_splash/issues/127).
+- Adds null safety. Closes [#127](https://github.com/jonbhanson/flutter_native_splash/issues/127).
 
 ## [0.3.0] - (2021-Feb-10)
 
-* Added support for web.  Closes [#30](https://github.com/jonbhanson/flutter_native_splash/issues/30).
-* Updated the example app to include web.
+- Added support for web. Closes [#30](https://github.com/jonbhanson/flutter_native_splash/issues/30).
+- Updated the example app to include web.
 
 ## [0.2.11] - (2021-Feb-09)
 
-* Fixed `remove` command which was leaving splash images in place.
+- Fixed `remove` command which was leaving splash images in place.
 
 ## [0.2.10] - (2021-Feb-08)
 
-* Replaced `android_fullscreen` with `fullscreen` parameter, adding iOS support. closes [#75](https://github.com/jonbhanson/flutter_native_splash/issues/75), closes [#65](https://github.com/jonbhanson/flutter_native_splash/issues/65).
-* The package no longer modifies the AppDelegate.  Fixes [#125](https://github.com/jonbhanson/flutter_native_splash/issues/125), fixes [#66](https://github.com/jonbhanson/flutter_native_splash/issues/66).
-* Added `remove` command.  Closes [#97](https://github.com/jonbhanson/flutter_native_splash/issues/97), closes [#126](https://github.com/jonbhanson/flutter_native_splash/issues/126).
-* Updated docs.
+- Replaced `android_fullscreen` with `fullscreen` parameter, adding iOS support. closes [#75](https://github.com/jonbhanson/flutter_native_splash/issues/75), closes [#65](https://github.com/jonbhanson/flutter_native_splash/issues/65).
+- The package no longer modifies the AppDelegate. Fixes [#125](https://github.com/jonbhanson/flutter_native_splash/issues/125), fixes [#66](https://github.com/jonbhanson/flutter_native_splash/issues/66).
+- Added `remove` command. Closes [#97](https://github.com/jonbhanson/flutter_native_splash/issues/97), closes [#126](https://github.com/jonbhanson/flutter_native_splash/issues/126).
+- Updated docs.
 
 ## [0.2.9] - (2021-Jan-27)
 
-* Correct iOS 2x scaling. Closes [#27](https://github.com/jonbhanson/flutter_native_splash/issues/27).
-* Fullscreen defaults to false.  Closes [#122](https://github.com/jonbhanson/flutter_native_splash/issues/122).
+- Correct iOS 2x scaling. Closes [#27](https://github.com/jonbhanson/flutter_native_splash/issues/27).
+- Fullscreen defaults to false. Closes [#122](https://github.com/jonbhanson/flutter_native_splash/issues/122).
 
 ## [0.2.8] - (2021-Jan-25)
 
-* Allow users to set Android gravity and iOS ContentMode directly. 
-* Parse LaunchScreen.storyboard with XML package for more reliability.  
-* Updated install instructions.  
-* Fixes [#18](https://github.com/jonbhanson/flutter_native_splash/issues/18). Closes [#63](https://github.com/jonbhanson/flutter_native_splash/pull/63).
+- Allow users to set Android gravity and iOS ContentMode directly.
+- Parse LaunchScreen.storyboard with XML package for more reliability.
+- Updated install instructions.
+- Fixes [#18](https://github.com/jonbhanson/flutter_native_splash/issues/18). Closes [#63](https://github.com/jonbhanson/flutter_native_splash/pull/63).
 
 ## [0.2.7] - (2021-Jan-18)
 
-* Added configuration parameter to specify the info.plist location(s). 
-* Updated documentation.  
-* Fixes [#120](https://github.com/jonbhanson/flutter_native_splash/issues/120), [#42](https://github.com/jonbhanson/flutter_native_splash/issues/42).
+- Added configuration parameter to specify the info.plist location(s).
+- Updated documentation.
+- Fixes [#120](https://github.com/jonbhanson/flutter_native_splash/issues/120), [#42](https://github.com/jonbhanson/flutter_native_splash/issues/42).
 
 ## [0.2.6] - (2021-Jan-14)
 
-* Added support for Android -v21 resource folders, which appear in the Flutter beta channel.  
-* Parse launch_background.xml with XML package for more reliability.  
-* Fixes [#104](https://github.com/jonbhanson/flutter_native_splash/issues/104), [#118](https://github.com/jonbhanson/flutter_native_splash/issues/118).
-
+- Added support for Android -v21 resource folders, which appear in the Flutter beta channel.
+- Parse launch_background.xml with XML package for more reliability.
+- Fixes [#104](https://github.com/jonbhanson/flutter_native_splash/issues/104), [#118](https://github.com/jonbhanson/flutter_native_splash/issues/118).
 
 ## [0.2.5] - (2021-Jan-13)
 
-* Handle color parameter that are passed as integers.  Fixes [#103](https://github.com/jonbhanson/flutter_native_splash/issues/103)
+- Handle color parameter that are passed as integers. Fixes [#103](https://github.com/jonbhanson/flutter_native_splash/issues/103)
 
 ## [0.2.4] - (2021-Jan-12)
 
-* Update code that adds fullscreen mode to Android so that it selects the right style (LaunchTheme) in styles.xml.  This should resolve [#39](https://github.com/jonbhanson/flutter_native_splash/issues/39), [#54](https://github.com/jonbhanson/flutter_native_splash/issues/54), [#67](https://github.com/jonbhanson/flutter_native_splash/issues/67), [#92](https://github.com/jonbhanson/flutter_native_splash/issues/92), [#112](https://github.com/jonbhanson/flutter_native_splash/issues/112), and [#117](https://github.com/jonbhanson/flutter_native_splash/issues/117).  
-* Removed code that modifies MainActivity as it is not longer needed since Flutter embedding V2 uses two styles in styles.xml so full screen is set independently in the style.
+- Update code that adds fullscreen mode to Android so that it selects the right style (LaunchTheme) in styles.xml. This should resolve [#39](https://github.com/jonbhanson/flutter_native_splash/issues/39), [#54](https://github.com/jonbhanson/flutter_native_splash/issues/54), [#67](https://github.com/jonbhanson/flutter_native_splash/issues/67), [#92](https://github.com/jonbhanson/flutter_native_splash/issues/92), [#112](https://github.com/jonbhanson/flutter_native_splash/issues/112), and [#117](https://github.com/jonbhanson/flutter_native_splash/issues/117).
+- Removed code that modifies MainActivity as it is not longer needed since Flutter embedding V2 uses two styles in styles.xml so full screen is set independently in the style.
 
 ## [0.2.3] - (2021-Jan-11)
 
-* Further modifications to raise [pub points](https://pub.dev/help/scoring): The 
-public API's need to have dartdoc comments, so all public declarations that did not
-need to be public were changed to private.  Added doc comments for public APIs. 
+- Further modifications to raise [pub points](https://pub.dev/help/scoring): The
+  public API's need to have dartdoc comments, so all public declarations that did not
+  need to be public were changed to private. Added doc comments for public APIs.
 
 ## [0.2.2] - (2021-Jan-09)
 
-* Corrected color of background PNG for iOS.  ([The channel order of a uint32 encoded color is BGRA.](https://pub.dev/documentation/image/latest/image/Color/fromRgb.html)) ([#115](https://github.com/jonbhanson/flutter_native_splash/issues/115))
+- Corrected color of background PNG for iOS. ([The channel order of a uint32 encoded color is BGRA.](https://pub.dev/documentation/image/latest/image/Color/fromRgb.html)) ([#115](https://github.com/jonbhanson/flutter_native_splash/issues/115))
 
 ## [0.2.1] - (2021-Jan-08)
 
-* Modifications to raise [pub points](https://pub.dev/help/scoring): Adherence to [Pedantic](https://pub.dev/packages/pedantic) code standard, and [conditional imports](https://dart.dev/guides/libraries/create-library-packages#conditionally-importing-and-exporting-library-files) to avoid losing points for lack of multiple platform support.
+- Modifications to raise [pub points](https://pub.dev/help/scoring): Adherence to [Pedantic](https://pub.dev/packages/pedantic) code standard, and [conditional imports](https://dart.dev/guides/libraries/create-library-packages#conditionally-importing-and-exporting-library-files) to avoid losing points for lack of multiple platform support.
 
 ## [0.2.0+1] - (2021-Jan-08)
 
-* Updated version number in README.md (thanks [@M123-dev](https://github.com/M123-dev))
+- Updated version number in README.md (thanks [@M123-dev](https://github.com/M123-dev))
 
 ## [0.2.0] - (2021-Jan-07)
 
-* Added dark mode.
+- Added dark mode.
 
-## [0.1.9] - 
+## [0.1.9] -
 
-* (2020-Jan-27) Added createSplashByConfig for external usage
-* (2020-Jan-05) Fix run the package command (thanks [@tenhobi](https://github.com/tenhobi))
-* (2019-Oct-31) Removing comments from the example (thanks [@lucalves](https://github.com/lucalves))
-* (2019-Oct-16) `image` parameter is now optional ([#26](https://github.com/jonbhanson/flutter_native_splash/issues/26))
+- (2020-Jan-27) Added createSplashByConfig for external usage
+- (2020-Jan-05) Fix run the package command (thanks [@tenhobi](https://github.com/tenhobi))
+- (2019-Oct-31) Removing comments from the example (thanks [@lucalves](https://github.com/lucalves))
+- (2019-Oct-16) `image` parameter is now optional ([#26](https://github.com/jonbhanson/flutter_native_splash/issues/26))
 
 ## [0.1.8+4] - (12th October 2019)
 
-* Fix bug on RegEx preventing `package` tag from being found in `AndroidManifest.xml` ([#25](https://github.com/jonbhanson/flutter_native_splash/issues/25))
+- Fix bug on RegEx preventing `package` tag from being found in `AndroidManifest.xml` ([#25](https://github.com/jonbhanson/flutter_native_splash/issues/25))
 
 ## [0.1.8+3] - (4th October 2019)
 
-* Prevent unhandled int exception in `color` argument (thanks [@wemersonrv](https://github.com/wemersonrv) - PR [#23](https://github.com/jonbhanson/flutter_native_splash/pull/23))
+- Prevent unhandled int exception in `color` argument (thanks [@wemersonrv](https://github.com/wemersonrv) - PR [#23](https://github.com/jonbhanson/flutter_native_splash/pull/23))
 
 ## [0.1.8+2] - (16th September 2019)
 
-* Fix code being added multiple times to `MainActivity` ([#19](https://github.com/jonbhanson/flutter_native_splash/issues/19))
+- Fix code being added multiple times to `MainActivity` ([#19](https://github.com/jonbhanson/flutter_native_splash/issues/19))
 
 ## [0.1.8+1] - (16th September 2019)
 
-* Documentation improvements
+- Documentation improvements
 
 ## [0.1.8] - (16th September 2019)
 
-* Added `fill` property to use full screen images on Android (thanks [@Bwofls2](https://github.com/Bwolfs2) - PR [#8](https://github.com/jonbhanson/flutter_native_splash/pull/8)) 
-* Added `android_disable_fullscreen` property to disable opening app in full screen on Android ([#14](https://github.com/jonbhanson/flutter_native_splash/issues/14))
-* Status bar color on Android is now generated dynamically by using same principles as Material Design (thanks [@yiss](https://github.com/yiss) - PR [#16](https://github.com/jonbhanson/flutter_native_splash/pull/16))
+- Added `fill` property to use full screen images on Android (thanks [@Bwofls2](https://github.com/Bwolfs2) - PR [#8](https://github.com/jonbhanson/flutter_native_splash/pull/8))
+- Added `android_disable_fullscreen` property to disable opening app in full screen on Android ([#14](https://github.com/jonbhanson/flutter_native_splash/issues/14))
+- Status bar color on Android is now generated dynamically by using same principles as Material Design (thanks [@yiss](https://github.com/yiss) - PR [#16](https://github.com/jonbhanson/flutter_native_splash/pull/16))
 
 ## [0.1.7+2] - (1th September 2019)
 
-* Fix a bug on `minSdkVersion` reading ([#13](https://github.com/jonbhanson/flutter_native_splash/issues/13))
+- Fix a bug on `minSdkVersion` reading ([#13](https://github.com/jonbhanson/flutter_native_splash/issues/13))
 
 ## [0.1.7+1] - (1th September 2019)
 
-* Check for `minSdkVersion` >= 21 to add code for changing status bar color to transparent ([#12](https://github.com/jonbhanson/flutter_native_splash/issues/12))
+- Check for `minSdkVersion` >= 21 to add code for changing status bar color to transparent ([#12](https://github.com/jonbhanson/flutter_native_splash/issues/12))
 
 ## [0.1.7] - (27th August 2019)
 
-* Fix a bug that duplicates entries on `Info.plist` when using multiple `</dict>` on iOS ([#5](https://github.com/jonbhanson/flutter_native_splash/issues/5))
-* Fix missing imports on `MainActivity` when not using default class signature ([#7](https://github.com/jonbhanson/flutter_native_splash/issues/7))
+- Fix a bug that duplicates entries on `Info.plist` when using multiple `</dict>` on iOS ([#5](https://github.com/jonbhanson/flutter_native_splash/issues/5))
+- Fix missing imports on `MainActivity` when not using default class signature ([#7](https://github.com/jonbhanson/flutter_native_splash/issues/7))
 
 ## [0.1.6+2] - (27th August 2019)
 
-* Yup, I released a new version because a quote was missing
+- Yup, I released a new version because a quote was missing
 
 ## [0.1.6+1] - (27th August 2019)
 
-* Updated README.md adding quotes on `color` property
-* Add support for colors with `#` prefix
+- Updated README.md adding quotes on `color` property
+- Add support for colors with `#` prefix
 
 ## [0.1.6] - (26th August 2019)
 
-* Fix bug where `MainActivity` file could not be found with custom package names
+- Fix bug where `MainActivity` file could not be found with custom package names
 
 ## [0.1.5] - (26th August 2019)
 
-* Add support for Kotlin
-* Add support for Swift
-* Add `await` to every step to create splash screen on Android and iOS to prevent async steps causing error
+- Add support for Kotlin
+- Add support for Swift
+- Add `await` to every step to create splash screen on Android and iOS to prevent async steps causing error
 
 ## [0.1.4] - (25th August 2019)
 
-* Fix code style issues pointed by `dartanalzyer`
-* Fix typo in README.md
+- Fix code style issues pointed by `dartanalzyer`
+- Fix typo in README.md
 
 ## [0.1.3] - (25th August 2019)
 
-* Update README.md
+- Update README.md
 
 ## [0.1.2] - (25th August 2019)
 
-* Fix Travis CI filename
-
+- Fix Travis CI filename
 
 ## [0.1.1] - (25th August 2019)
 
-* Added Travis CI and updates to README.md
-
+- Added Travis CI and updates to README.md
 
 ## [0.1.0] - (25th August 2019)
 
-* Initial release: generate Android and iOS splash screens with a background color and an image
+- Initial release: generate Android and iOS splash screens with a background color and an image

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ flutter_native_splash:
   #image: assets/splash.png
 
   # The branding property allows you to specify an image used as branding in the splash screen.
-  # It must be a png file. Currently, it is only supported for Android < v12 and iOS.
+  # It must be a png file. It is supported for Android < v12, iOS and the Web.
   #branding: assets/dart.png
 
   # To position the branding image at the bottom of the screen you can use bottom, bottomRight,

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-When your app is opened, there is a brief time while the native app loads Flutter.  By default, during this time, the native app displays a white splash screen.  This package automatically generates iOS, Android, and Web-native code for customizing this native splash screen background color and splash image.  Supports dark mode, full screen, and platform-specific options.
+When your app is opened, there is a brief time while the native app loads Flutter. By default, during this time, the native app displays a white splash screen. This package automatically generates iOS, Android, and Web-native code for customizing this native splash screen background color and splash image. Supports dark mode, full screen, and platform-specific options.
 
 <p align='center'>
     <img src="https://raw.githubusercontent.com/jonbhanson/flutter_native_splash/master/splash_demo.gif" />
@@ -9,11 +9,11 @@ When your app is opened, there is a brief time while the native app loads Flutte
 
 **\[BETA\]** Support for flavors is in beta. Currently only Android and iOS are supported. See instructions below.
 
-You can now keep the splash screen up while your app initializes!  No need for a secondary splash screen anymore.  Just use the `preserve` and `remove` methods together to remove the splash screen after your initialization is complete.  See [details below](https://pub.dev/packages/flutter_native_splash#3-set-up-app-initialization-optional).
+You can now keep the splash screen up while your app initializes! No need for a secondary splash screen anymore. Just use the `preserve` and `remove` methods together to remove the splash screen after your initialization is complete. See [details below](https://pub.dev/packages/flutter_native_splash#3-set-up-app-initialization-optional).
 
 # Usage
 
-Would you prefer a video tutorial instead?  Check out <a href="https://www.youtube.com/watch?v=dB0dOnc2k10">Johannes Milke's tutorial</a>.
+Would you prefer a video tutorial instead? Check out <a href="https://www.youtube.com/watch?v=dB0dOnc2k10">Johannes Milke's tutorial</a>.
 
 First, add `flutter_native_splash` as a dependency in your pubspec.yaml file.
 
@@ -25,11 +25,11 @@ dependencies:
 Don't forget to `flutter pub get`.
 
 ## 1. Setting the splash screen
+
 Customize the following settings and add to your project's `pubspec.yaml` file or place in a new file in your root project folder named `flutter_native_splash.yaml`.
 
 ```yaml
 flutter_native_splash:
-
   # This package generates native code to customize Flutter's default white native splash screen
   # with background color and splash image.
   # Customize the parameters below, and run the following command in the terminal:
@@ -100,7 +100,7 @@ flutter_native_splash:
   #android: false
   #ios: false
   #web: false
-  
+
   # Platform specific images can be specified with the following parameters, which will override
   # the respective image parameter.  You may specify all, selected, or none of these parameters:
   #image_andriod: assets/splash-andriod.png
@@ -119,7 +119,7 @@ flutter_native_splash:
   #branding_dark_android: assets/dart_dark-android.png
   #branding_ios: assets/brand-ios.png
   #branding_dark_ios: assets/dart_dark-ios.png
-  
+
   # The position of the splash image can be set with android_gravity, ios_content_mode, and
   # web_image_mode parameters.  All default to center.
   #
@@ -150,8 +150,8 @@ flutter_native_splash:
   #       WidgetsFlutterBinding.ensureInitialized();
   #       SystemChrome.setEnabledSystemUIOverlays([SystemUiOverlay.bottom, SystemUiOverlay.top]);
   #fullscreen: true
-  
-  # If you have changed the name(s) of your info.plist file(s), you can specify the filename(s) 
+
+  # If you have changed the name(s) of your info.plist file(s), you can specify the filename(s)
   # with the info_plist_files parameter.  Remove only the # characters in the three lines below,
   # do not remove any spaces:
   #info_plist_files:
@@ -160,6 +160,7 @@ flutter_native_splash:
 ```
 
 ## 2. Run the package
+
 After adding your settings, run the following command in the terminal:
 
 ```
@@ -176,7 +177,7 @@ flutter pub run flutter_native_splash:create --path=path/to/my/file.yaml
 
 ## 3. Set up app initialization (optional)
 
-By default, the splash screen will be removed when Flutter has drawn the first frame.  If you would like the splash screen to remain while your app initializes, you can use the `preserve()` and `remove()` methods together.  Pass the `preserve()` method the value returned from `WidgetsFlutterBinding.ensureInitialized()` to keep the splash on screen.  Later, when your app has initialized, make a call to `remove()` to remove the splash screen.
+By default, the splash screen will be removed when Flutter has drawn the first frame. If you would like the splash screen to remain while your app initializes, you can use the `preserve()` and `remove()` methods together. Pass the `preserve()` method the value returned from `WidgetsFlutterBinding.ensureInitialized()` to keep the splash on screen. Later, when your app has initialized, make a call to `remove()` to remove the splash screen.
 
 ```dart
 import 'package:flutter_native_splash/flutter_native_splash.dart';
@@ -192,29 +193,32 @@ void main() {
 
 ```
 
-
 NOTE: In order to use this method, the `flutter_native_splash` dependency must be in the `dependencies` section of `pubspec.yaml`, not in the `dev_dependencies` as was the case in previous versions of this package.
 
 ## 4. Support the package (optional)
-If you find this package useful, you can support it for free by giving it a thumbs up at the top of this page.  Here's another option to support the package:
+
+If you find this package useful, you can support it for free by giving it a thumbs up at the top of this page. Here's another option to support the package:
+
 <p align='center'><a href="https://www.buymeacoffee.com/jonhanson"><img src="https://img.buymeacoffee.com/button-api/?text=Buy me a coffee&emoji=&slug=jonhanson&button_colour=5F7FFF&font_colour=ffffff&font_family=Cookie&outline_colour=000000&coffee_colour=FFDD00"></a></p>
 
 # Android 12 Support
 
-Android 12 has a [new method](https://developer.android.com/about/versions/12/features/splash-screen) of adding splash screens, which consists of a window background, icon, and the icon background.  Note that a background image is not supported.
+Android 12 has a [new method](https://developer.android.com/about/versions/12/features/splash-screen) of adding splash screens, which consists of a window background, icon, and the icon background. Note that a background image is not supported.
 
 The package provides Android 12 support while maintaining the legacy splash screen for previous versions of Android.
 
-***PLEASE NOTE:*** The splash screen may not appear when you launch the app from Android Studio.  However, it should appear when you launch by clicking on the launch icon in Android.
+**_PLEASE NOTE:_** The splash screen may not appear when you launch the app from Android Studio. However, it should appear when you launch by clicking on the launch icon in Android.
 
-***PLEASE NOTE:*** There are a number of reports that non-Google launchers do not display the launch image correctly.  If the launch image does not display correctly, please try the Google launcher to confirm that this package is working.
-  
+**_PLEASE NOTE:_** There are a number of reports that non-Google launchers do not display the launch image correctly. If the launch image does not display correctly, please try the Google launcher to confirm that this package is working.
+
 # Flavor Support
+
 If you have a project setup that contains multiple flavors or environments, and you created more than one flavor this would be a feature for you.
 
 Instead of maintaining multiple files and copy/pasting images, you can now, using this tool, create different splash screens for different environments.
 
 ### Pre-requirements
+
 In order to use the new feature, and generate the desired splash images for you app, a couple of changes are required.
 
 If you want to generate just one flavor and one file you would use either options as described in Step 1. But in order to setup the flavors, you will then be required to move all your setup values to the `flutter_native_splash.yaml` file, but with a prefix.
@@ -222,12 +226,15 @@ If you want to generate just one flavor and one file you would use either option
 Let's assume for the rest of the setup that you have 3 different flavors, `Production`, `Acceptance`, `Development`.
 
 First this you will need to do is to create a different setup file for all 3 flavors with a suffix like so:
+
 ```bash
 flutter_native_splash-production.yaml
 flutter_native_splash-acceptance.yaml
 flutter_native_splash-development.yaml
 ```
+
 You would setup those 3 files the same way as you would the one, but with different assets depending on which environment you would be generating. For example (Note: these are just examples, you can use whatever setup you need for your project that is already supported by the package):
+
 ```yaml
 # flutter_native_splash-development.yaml
 flutter_native_splash:
@@ -243,7 +250,7 @@ flutter_native_splash:
     icon_background_color: "#ffffff"
     image_dark: assets/logo-development.png
     icon_background_color_dark: "#121212"
-  
+
   web: false
 
 # flutter_native_splash-acceptance.yaml
@@ -260,7 +267,7 @@ flutter_native_splash:
     icon_background_color: "#ffffff"
     image_dark: assets/logo-acceptance.png
     icon_background_color_dark: "#121212"
-  
+
   web: false
 
 # flutter_native_splash-production.yaml
@@ -277,13 +284,14 @@ flutter_native_splash:
     icon_background_color: "#ffffff"
     image_dark: assets/logo-production.png
     icon_background_color_dark: "#121212"
-  
+
   web: false
 ```
 
 Great, now comes the fun part running the new command!
 
 The new command is:
+
 ```bash
 # If you have a flavor called production you would do this:
 flutter pub run flutter_native_splash:create --flavor production
@@ -296,19 +304,23 @@ flutter pub run flutter_native_splash:create --flavor development
 ```
 
 ### Android setup
+
 You're done! No, really, Android doesn't need any additional setup.
 
 Note: If it didn't work, please make sure that your flavors are named the same as your config files, otherwise the setup will not work.
 
 ### iOS setup
+
 iOS is a bit tricky, so hang tight, it might look scary but most of the steps are just a single click, explained as much as possible to lower the possibility of mistakes.
 
 When you run the new command, you will need to open xCode and follow the steps bellow:
 
 Assumption
+
 - In order for this setup to work, you would already have 3 different `schemes` setup; production, acceptance and development.
 
 Preparation
+
 - Open the iOS Flutter project in Xcode (open the Runner.xcworkspace)
 - Find the newly created Storyboard files at the same location where the original is `{project root}/ios/Runner/Base.lproj`
 - Select all of them and drag and drop into Xcode, directly to the left hand side where the current LaunchScreen.storyboard is located already
@@ -318,6 +330,7 @@ Preparation
 xCode
 
 Xcode still doesn't know how to use them, so we need to specify for all the current flavors (schemes) which file to use and to use that value inside the Info.plist file.
+
 - Open the iOS Flutter project in Xcode (open the Runner.xcworkspace)
 - Click the Runner project in the top left corner (usually the first item in the list)
 - In the middle part of the screen, on the left side, select the Runner target
@@ -336,9 +349,10 @@ Xcode still doesn't know how to use them, so we need to specify for all the curr
 Congrats you finished your setup for multiple flavors,
 
 # FAQs
+
 ## I got the error "A splash screen was provided to Flutter, but this is deprecated."
 
-This message is not related to this package but is related to a [change](https://flutter.dev/docs/development/ui/advanced/splash-screen#migrating-from-manifest--activity-defined-custom-splash-screens) in how Flutter handles splash screens in Flutter 2.5.  It is caused by having the following code in your `android/app/src/main/AndroidManifest.xml`, which was included by default in previous versions of Flutter:
+This message is not related to this package but is related to a [change](https://flutter.dev/docs/development/ui/advanced/splash-screen#migrating-from-manifest--activity-defined-custom-splash-screens) in how Flutter handles splash screens in Flutter 2.5. It is caused by having the following code in your `android/app/src/main/AndroidManifest.xml`, which was included by default in previous versions of Flutter:
 
 ```xml
 <meta-data
@@ -346,47 +360,58 @@ This message is not related to this package but is related to a [change](https:/
  android:resource="@drawable/launch_background"
  />
 ```
-The solution is to remove the above code.  Note that this will also remove the fade effect between the native splash screen and your app.
+
+The solution is to remove the above code. Note that this will also remove the fade effect between the native splash screen and your app.
 
 ## Are animations/lottie/GIF images supported?
-Not at this time.  PRs are always welcome!
+
+Not at this time. PRs are always welcome!
 
 ## I got the error AAPT: error: style attribute 'android:attr/windowSplashScreenBackground' not found
-This attribute is only found in Android 12, so if you are getting this error, it means your project is not fully set up for Android 12.  Did you [update your app's build configuration](https://developer.android.com/about/versions/12/setup-sdk#config)?
+
+This attribute is only found in Android 12, so if you are getting this error, it means your project is not fully set up for Android 12. Did you [update your app's build configuration](https://developer.android.com/about/versions/12/setup-sdk#config)?
 
 ## I see a flash of the wrong splash screen on iOS
+
 This is caused by an [iOS splash caching bug](https://stackoverflow.com/questions/33002829/ios-keeping-old-launch-screen-and-app-icon-after-update), which can be solved by uninstalling your app, powering off your device, power back on, and then try reinstalling.
 
 ## I see a white screen between splash screen and app
+
 1. It may be caused by an [iOS splash caching bug](https://stackoverflow.com/questions/33002829/ios-keeping-old-launch-screen-and-app-icon-after-update), which can be solved by uninstalling your app, powering off your device, power back on, and then try reinstalling.
-2. It may be caused by the delay due to initialization in your app.  To solve this, put any initialization code in the `removeAfter` method.
+2. It may be caused by the delay due to initialization in your app. To solve this, put any initialization code in the `removeAfter` method.
 
 ## Can I base light/dark mode on app settings?
+
 No. This package creates a splash screen that is displayed before Flutter is loaded. Because of this, when the splash screen loads, internal app settings are not available to the splash screen. Unfortunately, this means that it is impossible to control light/dark settings of the splash from app settings.
 
 # Notes
-* If the splash screen was not updated correctly on iOS or if you experience a white screen before the splash screen, run `flutter clean` and recompile your app. If that does not solve the problem, delete your app, power down the device, power up the device, install and launch the app as per [this StackOverflow thread](https://stackoverflow.com/questions/33002829/ios-keeping-old-launch-screen-and-app-icon-after-update).
 
-* This package modifies `launch_background.xml` and `styles.xml` files on Android, `LaunchScreen.storyboard` and `Info.plist` on iOS, and `index.html` on Web. If you have modified these files manually, this plugin may not work properly. Please [open an issue](https://github.com//jonbhanson/flutter_native_splash/issues/new?template=bug_report.md) if you find any bugs.
+- If the splash screen was not updated correctly on iOS or if you experience a white screen before the splash screen, run `flutter clean` and recompile your app. If that does not solve the problem, delete your app, power down the device, power up the device, install and launch the app as per [this StackOverflow thread](https://stackoverflow.com/questions/33002829/ios-keeping-old-launch-screen-and-app-icon-after-update).
+
+- This package modifies `launch_background.xml` and `styles.xml` files on Android, `LaunchScreen.storyboard` and `Info.plist` on iOS, and `index.html` on Web. If you have modified these files manually, this plugin may not work properly. Please [open an issue](https://github.com//jonbhanson/flutter_native_splash/issues/new?template=bug_report.md) if you find any bugs.
 
 # How it works
+
 ## Android
-* Your splash image will be resized to `mdpi`, `hdpi`, `xhdpi`, `xxhdpi` and `xxxhdpi` drawables.
-* An `<item>` tag containing a `<bitmap>` for your splash image drawable will be added in `launch_background.xml`
-* Background color will be added in `colors.xml` and referenced in `launch_background.xml`.
-* Code for full screen mode toggle will be added in `styles.xml`.
-* Dark mode variants are placed in `drawable-night`, `values-night`, etc. resource folders.
+
+- Your splash image will be resized to `mdpi`, `hdpi`, `xhdpi`, `xxhdpi` and `xxxhdpi` drawables.
+- An `<item>` tag containing a `<bitmap>` for your splash image drawable will be added in `launch_background.xml`
+- Background color will be added in `colors.xml` and referenced in `launch_background.xml`.
+- Code for full screen mode toggle will be added in `styles.xml`.
+- Dark mode variants are placed in `drawable-night`, `values-night`, etc. resource folders.
 
 ## iOS
-* Your splash image will be resized to `@3x` and `@2x` images.
-* Color and image properties will be inserted in `LaunchScreen.storyboard`.
-* The background color is implemented by using a single-pixel png file and stretching it to fit the screen.
-* Code for hidden status bar toggle will be added in `Info.plist`.
+
+- Your splash image will be resized to `@3x` and `@2x` images.
+- Color and image properties will be inserted in `LaunchScreen.storyboard`.
+- The background color is implemented by using a single-pixel png file and stretching it to fit the screen.
+- Code for hidden status bar toggle will be added in `Info.plist`.
 
 ## Web
-* A `web/splash` folder will be created for splash screen images and CSS files.
-* Your splash image will be resized to `1x`, `2x`, `3x`, and `4x` sizes and placed in `web/splash/img`.
-* The splash style sheet will be added to the app's `web/index.html`, as well as the HTML for the splash pictures.
+
+- A `web/splash` folder will be created for splash screen images and CSS files.
+- Your splash image will be resized to `1x`, `2x`, `3x`, and `4x` sizes and placed in `web/splash/img`.
+- The splash style sheet will be added to the app's `web/index.html`, as well as the HTML for the splash pictures.
 
 # Acknowledgments
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -96,7 +96,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.2.1"
+    version: "2.2.4"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -244,7 +244,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.1"
+    version: "6.1.0"
   yaml:
     dependency: transitive
     description:

--- a/lib/cli_commands.dart
+++ b/lib/cli_commands.dart
@@ -65,12 +65,16 @@ void createSplashByConfig(Map<String, dynamic> config) {
       _checkImageExists(config: config, parameter: 'branding_android');
   final String? brandingImageIos =
       _checkImageExists(config: config, parameter: 'branding_ios');
+  final String? brandingImageWeb =
+      _checkImageExists(config: config, parameter: 'branding_web');
   final String? brandingDarkImage =
       _checkImageExists(config: config, parameter: 'branding_dark');
   final String? brandingDarkImageAndroid =
       _checkImageExists(config: config, parameter: 'branding_dark_android');
   final String? brandingDarkImageIos =
       _checkImageExists(config: config, parameter: 'branding_dark_ios');
+  final String? brandingDarkImageWeb =
+      _checkImageExists(config: config, parameter: 'branding_dark_web');
   final String? color = parseColor(config['color']);
   final String? darkColor = parseColor(config['color_dark']);
   final String? backgroundImage =
@@ -84,7 +88,9 @@ void createSplashByConfig(Map<String, dynamic> config) {
   final String? darkBackgroundImage =
       _checkImageExists(config: config, parameter: 'background_image_dark');
   final String? darkBackgroundImageAndroid = _checkImageExists(
-      config: config, parameter: 'background_image_dark_android');
+    config: config,
+    parameter: 'background_image_dark_android',
+  );
   final String? darkBackgroundImageIos =
       _checkImageExists(config: config, parameter: 'background_image_dark_ios');
   final String? darkBackgroundImageWeb =
@@ -178,6 +184,8 @@ void createSplashByConfig(Map<String, dynamic> config) {
         darkImagePath: darkImageWeb ?? darkImage,
         backgroundImage: backgroundImageWeb ?? backgroundImage,
         darkBackgroundImage: darkBackgroundImageWeb ?? darkBackgroundImage,
+        brandingImagePath: brandingImageWeb ?? brandingImage,
+        brandingDarkImagePath: brandingDarkImageWeb ?? brandingDarkImage,
         color: color,
         darkColor: darkColor,
         imageMode: webImageMode,

--- a/lib/cli_commands.dart
+++ b/lib/cli_commands.dart
@@ -189,6 +189,7 @@ void createSplashByConfig(Map<String, dynamic> config) {
         color: color,
         darkColor: darkColor,
         imageMode: webImageMode,
+        brandingMode: brandingGravity,
       );
     } else {
       print('Web folder not found, skipping web splash update...');

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -470,6 +470,26 @@ body {
   object-fit: cover;
 }
 
+.bottom {
+  position: absolute;
+  bottom: 0;
+  left: 50%;
+  -ms-transform: translate(-50%, 0);
+  transform: translate(-50%, 0);
+}
+
+.bottomLeft {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+}
+
+.bottomRight {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+}
+
 @media (prefers-color-scheme: dark) {
   body {
     margin:0;
@@ -489,11 +509,23 @@ const List<String> _indexHtmlPicture = [
   '  </picture>',
 ];
 
+const List<String> _indexHtmlBrandingPicture = [
+  '  <picture id="splash-branding">',
+  '    <source srcset="splash/img/branding-1x.png 1x, splash/img/branding-2x.png 2x, splash/img/branding-3x.png 3x, splash/img/branding-4x.png 4x" media="(prefers-color-scheme: light)">',
+  '    <source srcset="splash/img/branding-dark-1x.png 1x, splash/img/branding-dark-2x.png 2x, splash/img/branding-dark-3x.png 3x, splash/img/branding-dark-4x.png 4x" media="(prefers-color-scheme: dark)">',
+  '    <img class="[BRANDINGMODE]" aria-hidden="true" src="splash/img/branding-1x.png alt=""/>',
+  '  </picture>',
+];
+
 const String _webJS = '''
 function removeSplashFromWeb() {
   const elem = document.getElementById("splash");
   if (elem) {
     elem.remove();
+  }
+  const elem2 = document.getElementById("splash-branding");
+  if (elem2) {
+    elem2.remove();
   }
   document.body.style.background = "transparent";
 }

--- a/lib/web.dart
+++ b/lib/web.dart
@@ -13,6 +13,8 @@ void _createWebSplash({
   required String? darkImagePath,
   required String? color,
   required String? darkColor,
+  required String? brandingImagePath,
+  required String? brandingDarkImagePath,
   required String imageMode,
   required String? backgroundImage,
   required String? darkBackgroundImage,
@@ -41,6 +43,39 @@ void _createWebSplash({
       _WebLaunchImageTemplate(fileName: 'dark-4x.png', pixelDensity: 4),
     ],
   );
+
+  brandingDarkImagePath ??= brandingImagePath;
+  createWebImages(
+    imagePath: brandingImagePath,
+    webSplashImages: [
+      _WebLaunchImageTemplate(fileName: 'branding-1x.png', pixelDensity: 1),
+      _WebLaunchImageTemplate(fileName: 'branding-2x.png', pixelDensity: 2),
+      _WebLaunchImageTemplate(fileName: 'branding-3x.png', pixelDensity: 3),
+      _WebLaunchImageTemplate(fileName: 'branding-4x.png', pixelDensity: 4),
+    ],
+  );
+  createWebImages(
+    imagePath: brandingDarkImagePath,
+    webSplashImages: [
+      _WebLaunchImageTemplate(
+        fileName: 'branding-dark-1x.png',
+        pixelDensity: 1,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'branding-dark-2x.png',
+        pixelDensity: 2,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'branding-dark-3x.png',
+        pixelDensity: 3,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'branding-dark-4x.png',
+        pixelDensity: 4,
+      ),
+    ],
+  );
+
   createBackgroundImages(
     backgroundImage: backgroundImage,
     darkBackgroundImage: darkBackgroundImage,

--- a/lib/web.dart
+++ b/lib/web.dart
@@ -16,6 +16,7 @@ void _createWebSplash({
   required String? brandingImagePath,
   required String? brandingDarkImagePath,
   required String imageMode,
+  required String brandingMode,
   required String? backgroundImage,
   required String? darkBackgroundImage,
 }) {
@@ -87,7 +88,12 @@ void _createWebSplash({
     backgroundImage: backgroundImage,
   );
   _createSplashJs();
-  updateIndex(imageMode: imageMode, imagePath: imagePath);
+  updateIndex(
+    imageMode: imageMode,
+    imagePath: imagePath,
+    brandingMode: brandingMode,
+    brandingImagePath: brandingImagePath,
+  );
 }
 
 void createBackgroundImages({
@@ -198,7 +204,12 @@ void _createSplashJs() {
   file.writeAsStringSync(_webJS);
 }
 
-void updateIndex({required String imageMode, required String? imagePath}) {
+void updateIndex({
+  required String imageMode,
+  required String? imagePath,
+  required String brandingMode,
+  required String? brandingImagePath,
+}) {
   print('[Web] Updating index.html');
   final webIndex = File(_webIndex);
   final lines = webIndex.readAsLinesSync();
@@ -209,6 +220,7 @@ void updateIndex({required String imageMode, required String? imagePath}) {
   var headCloseTagLine = 0;
   var bodyOpenTagLine = 0;
   var existingPictureLine = 0;
+  var existingBrandingPictureLine = 0;
 
   const styleSheetLink =
       '<link rel="stylesheet" type="text/css" href="splash/style.css">';
@@ -234,6 +246,8 @@ void updateIndex({required String imageMode, required String? imagePath}) {
       bodyOpenTagLine = x;
     } else if (line.contains('<picture id="splash">')) {
       existingPictureLine = x;
+    } else if (line.contains('<picture id="splash-branding">')) {
+      existingBrandingPictureLine = x;
     }
   }
 
@@ -265,6 +279,27 @@ void updateIndex({required String imageMode, required String? imagePath}) {
       lines.removeRange(
         existingPictureLine,
         existingPictureLine + _indexHtmlPicture.length,
+      );
+    }
+  }
+
+  if (existingBrandingPictureLine == 0) {
+    if (brandingImagePath != null) {
+      for (var x = _indexHtmlBrandingPicture.length - 1; x >= 0; x--) {
+        lines[bodyOpenTagLine + 1] =
+            '${_indexHtmlBrandingPicture[x].replaceFirst('[BRANDINGMODE]', brandingMode)}\n${lines[bodyOpenTagLine + 1]}';
+      }
+    }
+  } else {
+    if (brandingImagePath != null) {
+      for (var x = 0; x < _indexHtmlBrandingPicture.length; x++) {
+        lines[existingBrandingPictureLine + x] = _indexHtmlBrandingPicture[x]
+            .replaceFirst('[BRANDINGMODE]', brandingMode);
+      }
+    } else {
+      lines.removeRange(
+        existingBrandingPictureLine,
+        existingBrandingPictureLine + _indexHtmlBrandingPicture.length,
       );
     }
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   yaml: ^3.1.1
 
 dev_dependencies:
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1
   flutter_test:
     sdk: flutter
 


### PR DESCRIPTION
## New
- Branding image support for web platform

## Changes
- Updated dependencies like `flutter_lints`
- Added HTML, CSS and JS template for branding image
- Creates different pixel ratio branding images in the directory `web/splash/img/`

Resolves #385 