### PR TITLE
Update pub.dev links

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,8 @@ name: flutter_native_splash
 description: Customize Flutter's default white native splash screen with
   background color and splash image. Supports dark mode, full screen, and more.
 version: 2.2.8
-homepage: https://github.com/jonbhanson/flutter_native_splash
+repository: https://github.com/jonbhanson/flutter_native_splash
+issue_tracker: https://github.com/jonbhanson/flutter_native_splash/issues
 
 environment:
   sdk: ">=2.15.1 <3.0.0"


### PR DESCRIPTION
With this PR, the right section on pub.dev will show the View/report issues link to GitHub again, like [here](https://pub.dev/packages/android_id) (the show-logic was recently changed).