### PR TITLE
Fix generation for already supported image formats

### DIFF
--- a/lib/cli_commands.dart
+++ b/lib/cli_commands.dart
@@ -284,15 +284,49 @@ String? _checkImageExists({
       exit(1);
     }
 
-    if (p.extension(image).toLowerCase() != '.png') {
+    // https://github.com/brendan-duncan/image#supported-image-formats
+    final List<String> supportedFormats = [
+      "png", "apng", // PNG
+      "jpg", "jpeg", "jpe", "jfif", // JPEG
+      "tga", "tpic", // TGA
+      "gif", // GIF
+      "ico", // ICO
+      "bmp", "dib", // BMP
+    ];
+
+    if (!supportedFormats
+        .any((format) => p.extension(image).toLowerCase() == ".$format")) {
       print(
-        'Unsupported file format: $image  Your image must be a PNG file.',
+        'Unsupported file format: $image  Your image must be in one of the following formats: $supportedFormats',
       );
       exit(1);
     }
   }
 
   return image == '' ? null : image;
+}
+
+void createBackgroundImage({
+  required String imageDestination,
+  required String imageSource,
+}) {
+  // Copy will not work if the directory does not exist, so createSync
+  // will ensure that the directory exists.
+  File(imageDestination).createSync(recursive: true);
+
+  // If source image is not already png, convert it, otherwise just copy it.
+  if (p.extension(imageSource).toLowerCase() != '.png') {
+    final image = decodeImage(File(imageSource).readAsBytesSync());
+    if (image == null) {
+      print('$imageSource could not be read');
+      exit(1);
+    }
+    File(imageDestination)
+      ..createSync(recursive: true)
+      ..writeAsBytesSync(encodePng(image));
+  } else {
+    File(imageSource).copySync(imageDestination);
+  }
 }
 
 /// Get config from `pubspec.yaml` or `flutter_native_splash.yaml`

--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -433,10 +433,10 @@ void _createBackground({
     file.createSync(recursive: true);
     file.writeAsBytesSync(encodePng(background));
   } else if (backgroundImageSource != null) {
-    // Copy will not work if the directory does not exist, so createSync
-    // will ensure that the directory exists.
-    File(backgroundImageDestination).createSync(recursive: true);
-    File(backgroundImageSource).copySync(backgroundImageDestination);
+    createBackgroundImage(
+      imageDestination: backgroundImageDestination,
+      imageSource: backgroundImageSource,
+    );
   } else {
     throw Exception('No color string or background image!');
   }
@@ -453,10 +453,10 @@ void _createBackground({
     file.createSync(recursive: true);
     file.writeAsBytesSync(encodePng(background));
   } else if (darkBackgroundImageSource != null) {
-    // Copy will not work if the directory does not exist, so createSync
-    // will ensure that the directory exists.
-    File(darkBackgroundImageDestination).createSync(recursive: true);
-    File(darkBackgroundImageSource).copySync(darkBackgroundImageDestination);
+    createBackgroundImage(
+      imageDestination: darkBackgroundImageDestination,
+      imageSource: darkBackgroundImageSource,
+    );
   } else {
     final file = File(darkBackgroundImageDestination);
     if (file.existsSync()) file.deleteSync();

--- a/lib/web.dart
+++ b/lib/web.dart
@@ -101,27 +101,30 @@ void createBackgroundImages({
   required String? backgroundImage,
   required String? darkBackgroundImage,
 }) {
-  const backgroundDestination = '${_webSplashImagesFolder}light-background.png';
+  print('[Web] Creating background images');
+  _createBackgroundImage(
+    backgroundImage: backgroundImage,
+    fileName: "light-background.png",
+  );
+  _createBackgroundImage(
+    backgroundImage: darkBackgroundImage,
+    fileName: "dark-background.png",
+  );
+}
+
+void _createBackgroundImage({
+  required String? backgroundImage,
+  required String fileName,
+}) {
+  final backgroundDestination = '$_webSplashImagesFolder$fileName';
   if (backgroundImage == null) {
     final file = File(backgroundDestination);
     if (file.existsSync()) file.deleteSync();
   } else {
-    // Copy will not work if the directory does not exist, so createSync
-    // will ensure that the directory exists.
-    File(backgroundDestination).createSync(recursive: true);
-    File(backgroundImage).copySync(backgroundDestination);
-  }
-
-  const darkBackgroundDestination =
-      '${_webSplashImagesFolder}dark-background.png';
-  if (darkBackgroundImage == null) {
-    final file = File(darkBackgroundDestination);
-    if (file.existsSync()) file.deleteSync();
-  } else {
-    // Copy will not work if the directory does not exist, so createSync
-    // will ensure that the directory exists.
-    File(darkBackgroundDestination).createSync(recursive: true);
-    File(darkBackgroundImage).copySync(darkBackgroundDestination);
+    createBackgroundImage(
+      imageDestination: backgroundDestination,
+      imageSource: backgroundImage,
+    );
   }
 }
 


### PR DESCRIPTION
This PR fixes the support for the already supported image formats by the underlying library.
The existing logic of copying the background image has been changed to convert it to PNG and only copy it if it is already ".png".

https://github.com/brendan-duncan/image#supported-image-formats
> - PNG / Animated APNG
> - JPEG
> - Targa
> - GIF / Animated GIF
> - ICO
> - BMP