### PR TITLE
migrate to systemUIMode in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ flutter_native_splash:
   # NOTE: Unlike Android, iOS will not automatically show the notification bar when the app loads.
   #       To show the notification bar, add the following code to your Flutter app:
   #       WidgetsFlutterBinding.ensureInitialized();
-  #       SystemChrome.setEnabledSystemUIOverlays([SystemUiOverlay.bottom, SystemUiOverlay.top]);
+  #       SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual, overlays: [SystemUiOverlay.bottom, SystemUiOverlay.top], );
   #fullscreen: true
 
   # If you have changed the name(s) of your info.plist file(s), you can specify the filename(s)


### PR DESCRIPTION
As per the documentation, it is said to include a fix for the notification bar for iOS devices to show it when the app launches. As per vs code suggestion, setEnabledSystemUIOverlays' is deprecated and shouldn't be used. Migrate to setEnabledSystemUIMode. This feature was deprecated after v2.3.0-17.0.pre. so it might be better to migrate and have users use the newer type. 

idk about additional files that may need this change. Please have a look.