### PR TITLE
feat: support for GIFs in splash screen for web

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -131,10 +131,10 @@ packages:
     dependency: transitive
     description:
       name: image
-      sha256: "483a389d6ccb292b570c31b3a193779b1b0178e7eb571986d9a49904b6861227"
+      sha256: a72242c9a0ffb65d03de1b7113bc4e189686fc07c7147b8b41811d0dd0e0d9bf
       url: "https://pub.dev"
     source: hosted
-    version: "4.0.15"
+    version: "4.0.17"
   js:
     dependency: transitive
     description:

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -478,17 +478,17 @@ const String _webCssDark = '''
 // XML's insertBefore can't have a newline at the end:
 const String _indexHtmlPicture = '''
   <picture id="splash">
-      <source srcset="splash/img/light-1x.png 1x, splash/img/light-2x.png 2x, splash/img/light-3x.png 3x, splash/img/light-4x.png 4x" media="(prefers-color-scheme: light)">
-      <source srcset="splash/img/dark-1x.png 1x, splash/img/dark-2x.png 2x, splash/img/dark-3x.png 3x, splash/img/dark-4x.png 4x" media="(prefers-color-scheme: dark)">
-      <img class="[IMAGEMODE]" aria-hidden="true" src="splash/img/light-1x.png" alt=""/>
+      <source srcset="splash/img/light-1x.[IMAGEEXTENSION] 1x, splash/img/light-2x.[IMAGEEXTENSION] 2x, splash/img/light-3x.[IMAGEEXTENSION] 3x, splash/img/light-4x.[IMAGEEXTENSION] 4x" media="(prefers-color-scheme: light)">
+      <source srcset="splash/img/dark-1x.[IMAGEEXTENSION] 1x, splash/img/dark-2x.[IMAGEEXTENSION] 2x, splash/img/dark-3x.[IMAGEEXTENSION] 3x, splash/img/dark-4x.[IMAGEEXTENSION] 4x" media="(prefers-color-scheme: dark)">
+      <img class="[IMAGEMODE]" aria-hidden="true" src="splash/img/light-1x.[IMAGEEXTENSION]" alt=""/>
   </picture>''';
 
 // XML's insertBefore can't have a newline at the end:
 const String _indexHtmlBrandingPicture = '''
   <picture id="splash-branding">
-    <source srcset="splash/img/branding-1x.png 1x, splash/img/branding-2x.png 2x, splash/img/branding-3x.png 3x, splash/img/branding-4x.png 4x" media="(prefers-color-scheme: light)">
-    <source srcset="splash/img/branding-dark-1x.png 1x, splash/img/branding-dark-2x.png 2x, splash/img/branding-dark-3x.png 3x, splash/img/branding-dark-4x.png 4x" media="(prefers-color-scheme: dark)">
-    <img class="[BRANDINGMODE]" aria-hidden="true" src="splash/img/branding-1x.png" alt=""/>
+    <source srcset="splash/img/branding-1x.[BRANDINGEXTENSION] 1x, splash/img/branding-2x.[BRANDINGEXTENSION] 2x, splash/img/branding-3x.[BRANDINGEXTENSION] 3x, splash/img/branding-4x.[BRANDINGEXTENSION] 4x" media="(prefers-color-scheme: light)">
+    <source srcset="splash/img/branding-dark-1x.[BRANDINGEXTENSION] 1x, splash/img/branding-dark-2x.[BRANDINGEXTENSION] 2x, splash/img/branding-dark-3x.[BRANDINGEXTENSION] 3x, splash/img/branding-dark-4x.[BRANDINGEXTENSION] 4x" media="(prefers-color-scheme: dark)">
+    <img class="[BRANDINGMODE]" aria-hidden="true" src="splash/img/branding-1x.[BRANDINGEXTENSION]" alt=""/>
   </picture>''';
 
 const String _webJS = '''

--- a/lib/web.dart
+++ b/lib/web.dart
@@ -42,7 +42,8 @@ void _createWebSplash({
     // Remove items that may have been added to index.html:
     document
         .querySelector(
-            'link[rel="stylesheet"][type="text/css"][href="splash/style.css"]')
+          'link[rel="stylesheet"][type="text/css"][href="splash/style.css"]',
+        )
         ?.remove();
     document
         .querySelector(
@@ -57,52 +58,98 @@ void _createWebSplash({
   }
 
   darkImagePath ??= imagePath;
+  final imageExtension = (imagePath?.endsWith('.gif') ?? false) ? 'gif' : 'png';
+
   _createWebImages(
     imagePath: imagePath,
     webSplashImages: [
-      _WebLaunchImageTemplate(fileName: 'light-1x.png', pixelDensity: 1),
-      _WebLaunchImageTemplate(fileName: 'light-2x.png', pixelDensity: 2),
-      _WebLaunchImageTemplate(fileName: 'light-3x.png', pixelDensity: 3),
-      _WebLaunchImageTemplate(fileName: 'light-4x.png', pixelDensity: 4),
+      _WebLaunchImageTemplate(
+        fileName: 'light-1x.$imageExtension',
+        pixelDensity: 1,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'light-2x.$imageExtension',
+        pixelDensity: 2,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'light-3x.$imageExtension',
+        pixelDensity: 3,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'light-4x.$imageExtension',
+        pixelDensity: 4,
+      ),
     ],
   );
+  final darkImageExtension =
+      (darkImagePath?.endsWith('.gif') ?? false) ? 'gif' : 'png';
   _createWebImages(
     imagePath: darkImagePath,
     webSplashImages: [
-      _WebLaunchImageTemplate(fileName: 'dark-1x.png', pixelDensity: 1),
-      _WebLaunchImageTemplate(fileName: 'dark-2x.png', pixelDensity: 2),
-      _WebLaunchImageTemplate(fileName: 'dark-3x.png', pixelDensity: 3),
-      _WebLaunchImageTemplate(fileName: 'dark-4x.png', pixelDensity: 4),
+      _WebLaunchImageTemplate(
+        fileName: 'dark-1x.$darkImageExtension',
+        pixelDensity: 1,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'dark-2x.$darkImageExtension',
+        pixelDensity: 2,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'dark-3x.$darkImageExtension',
+        pixelDensity: 3,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'dark-4x.$darkImageExtension',
+        pixelDensity: 4,
+      ),
     ],
   );
 
   brandingDarkImagePath ??= brandingImagePath;
+  final brandingExtension =
+      (brandingImagePath?.endsWith('.gif') ?? false) ? 'gif' : 'png';
+
   _createWebImages(
     imagePath: brandingImagePath,
     webSplashImages: [
-      _WebLaunchImageTemplate(fileName: 'branding-1x.png', pixelDensity: 1),
-      _WebLaunchImageTemplate(fileName: 'branding-2x.png', pixelDensity: 2),
-      _WebLaunchImageTemplate(fileName: 'branding-3x.png', pixelDensity: 3),
-      _WebLaunchImageTemplate(fileName: 'branding-4x.png', pixelDensity: 4),
+      _WebLaunchImageTemplate(
+        fileName: 'branding-1x.$brandingExtension',
+        pixelDensity: 1,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'branding-2x.$brandingExtension',
+        pixelDensity: 2,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'branding-3x.$brandingExtension',
+        pixelDensity: 3,
+      ),
+      _WebLaunchImageTemplate(
+        fileName: 'branding-4x.$brandingExtension',
+        pixelDensity: 4,
+      ),
     ],
   );
+
+  final darkBrandingExtension =
+      (brandingDarkImagePath?.endsWith('.gif') ?? false) ? 'gif' : 'png';
   _createWebImages(
     imagePath: brandingDarkImagePath,
     webSplashImages: [
       _WebLaunchImageTemplate(
-        fileName: 'branding-dark-1x.png',
+        fileName: 'branding-dark-1x.$darkBrandingExtension',
         pixelDensity: 1,
       ),
       _WebLaunchImageTemplate(
-        fileName: 'branding-dark-2x.png',
+        fileName: 'branding-dark-2x.$darkBrandingExtension',
         pixelDensity: 2,
       ),
       _WebLaunchImageTemplate(
-        fileName: 'branding-dark-3x.png',
+        fileName: 'branding-dark-3x.$darkBrandingExtension',
         pixelDensity: 3,
       ),
       _WebLaunchImageTemplate(
-        fileName: 'branding-dark-4x.png',
+        fileName: 'branding-dark-4x.$darkBrandingExtension',
         pixelDensity: 4,
       ),
     ],
@@ -133,13 +180,19 @@ void createBackgroundImages({
   required String? darkBackgroundImage,
 }) {
   print('[Web] Creating background images');
+
+  final bgExtension =
+      (backgroundImage?.endsWith('.gif') ?? false) ? 'gif' : 'png';
   _createBackgroundImage(
     backgroundImage: backgroundImage,
-    fileName: "light-background.png",
+    fileName: "light-background.$bgExtension",
   );
+
+  final darkBgExtension =
+      (darkBackgroundImage?.endsWith('.gif') ?? false) ? 'gif' : 'png';
   _createBackgroundImage(
     backgroundImage: darkBackgroundImage,
-    fileName: "dark-background.png",
+    fileName: "dark-background.$darkBgExtension",
   );
 }
 
@@ -170,6 +223,7 @@ void _createWebImages({
     }
   } else {
     final image = decodeImage(File(imagePath).readAsBytesSync());
+
     if (image == null) {
       print('$imagePath could not be read');
       exit(1);
@@ -194,7 +248,9 @@ void _saveImageWeb({
 
   final file = File(_webSplashImagesFolder + template.fileName);
   file.createSync(recursive: true);
-  file.writeAsBytesSync(encodePng(newFile));
+  file.writeAsBytesSync(
+    (template.fileName.endsWith('.gif') ? encodeGif : encodePng)(newFile),
+  );
 }
 
 void _createSplashCss({
@@ -209,25 +265,32 @@ void _createSplashCss({
   var cssContent = _webCss.replaceFirst('[LIGHTBACKGROUNDCOLOR]', '#$color');
   if (darkColor != null || darkBackgroundImage != null || hasDarkImage) {
     darkColor ??= '000000';
-    cssContent +=
-        _webCssDark.replaceFirst('[DARKBACKGROUNDCOLOR]', '#$darkColor');
+    cssContent += _webCssDark.replaceFirst(
+      '[DARKBACKGROUNDCOLOR]',
+      '#$darkColor',
+    );
   }
 
   if (backgroundImage == null) {
     cssContent = cssContent.replaceFirst('  [LIGHTBACKGROUNDIMAGE]\n', '');
   } else {
+    final bgExtension = backgroundImage.endsWith('.gif') ? 'gif' : 'png';
+
     cssContent = cssContent.replaceFirst(
       '[LIGHTBACKGROUNDIMAGE]',
-      'background-image: url("img/light-background.png");',
+      'background-image: url("img/light-background.$bgExtension");',
     );
   }
 
-  if (backgroundImage == null) {
+  if (darkBackgroundImage == null) {
     cssContent = cssContent.replaceFirst('    [DARKBACKGROUNDIMAGE]\n', '');
   } else {
+    final darkBgExtension =
+        darkBackgroundImage.endsWith('.gif') ? 'gif' : 'png';
+
     cssContent = cssContent.replaceFirst(
       '[DARKBACKGROUNDIMAGE]',
-      'background-image: url("img/dark-background.png");',
+      'background-image: url("img/dark-background.$darkBgExtension");',
     );
   }
 
@@ -290,7 +353,15 @@ void _updateHtml({
   if (imagePath != null) {
     document.body?.insertBefore(
       html_parser.parseFragment(
-        _indexHtmlPicture.replaceAll('[IMAGEMODE]', imageMode),
+        _indexHtmlPicture
+            .replaceAll(
+              '[IMAGEMODE]',
+              imageMode,
+            )
+            .replaceAll(
+              '[IMAGEEXTENSION]',
+              imagePath.endsWith('.gif') ? 'gif' : 'png',
+            ),
         container: '',
       ),
       document.body?.firstChild,
@@ -302,7 +373,15 @@ void _updateHtml({
   if (brandingImagePath != null) {
     document.body?.insertBefore(
       html_parser.parseFragment(
-        _indexHtmlBrandingPicture.replaceAll('[BRANDINGMODE]', brandingMode),
+        _indexHtmlBrandingPicture
+            .replaceAll(
+              '[BRANDINGMODE]',
+              brandingMode,
+            )
+            .replaceAll(
+              '[BRANDINGEXTENSION]',
+              brandingImagePath.endsWith('.gif') ? 'gif' : 'png',
+            ),
         container: '',
       ),
       document.body?.firstChild,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
     sdk: flutter
   js: ^0.6.5
   html: ^0.15.2
-  image: ^4.0.15
+  image: ^4.0.17
   meta: ^1.8.0
   path: ^1.8.2
   universal_io: ^2.2.0


### PR DESCRIPTION
Added animated GIF support for branding, splash and background images on _web_.

<details><summary>Test Configuration Details</summary>

<details><summary>Images</summary>

| Main | Background | Branding |
|--------|--------|--------|
| ![loading-hand](https://user-images.githubusercontent.com/74326345/236673657-ab11ac6c-b7cc-489c-a813-421c67760e4f.gif) | ![splash-bg](https://user-images.githubusercontent.com/74326345/236673725-8a43aabb-69c6-4179-84e4-ea8a5720b774.png) | ![branding](https://user-images.githubusercontent.com/74326345/236673740-450a6139-c342-4dac-9113-676ae6fc4606.png) | 

</details> 

<details><summary>Config Code</summary>

```yaml
flutter_native_splash:
  # color: "#e1f5fe"
  background_image: "assets/splash-images/splash-bg.png"
  image: assets/splash-images/loading-hand.gif
  branding: assets/splash-images/branding.png

  # color_dark: "#042a49"
  background_image_dark: "assets/splash-images/splash-bg.png"
  image_dark: assets/splash-images/loading-hand.gif
  branding_dark: assets/splash-images/branding.png

  # The android, ios and web parameters can be used to disable generating a splash screen on a given
  # platform.
  android: false
  ios: false
  #web: false

  fullscreen: true
``` 
</details> 

</details> 

## Working

After running `flutter pub run flutter_native_splash:create`

### Before

<details><summary>See More</summary>

| pixelDensity | Resultant Image |
|--------|--------|
| 1 | ![light-1x](https://user-images.githubusercontent.com/74326345/236674075-09e9e876-1fbb-411d-a1a8-a6700e9651e0.png) |
| 2 | ![light-2x](https://user-images.githubusercontent.com/74326345/236674084-71838a98-42ec-47bc-8ae0-6955ebecfa7a.png) |
| 3 | ![light-3x](https://user-images.githubusercontent.com/74326345/236674088-77132fef-0951-46b6-9112-1bfed5a56258.png) |
| 4 | ![light-4x](https://user-images.githubusercontent.com/74326345/236674094-c220bc6d-feb9-44eb-a5c9-a27019c64e25.png) |
| Final Result | <img width="1312" alt="Screenshot 2023-05-07 at 4 26 35 PM" src="https://user-images.githubusercontent.com/74326345/236674100-5ecbcf95-9492-4465-98d2-bb0eb1450080.png"> | 

</details> 

### After

<details><summary>See More</summary>

| pixelDensity | Resultant Image |
|--------|--------|
| 1 | ![light-1x](https://user-images.githubusercontent.com/74326345/236674163-fa340dc0-4bff-436b-9b4a-80705ecc8cef.gif) |
| 2 | ![light-2x](https://user-images.githubusercontent.com/74326345/236674168-220f66de-a542-4a57-8232-572b451dcb20.gif) |
| 3 | ![light-3x](https://user-images.githubusercontent.com/74326345/236674169-8a094fe0-c730-4aa2-9317-a074176b56bd.gif) |
| 4 | ![light-4x](https://user-images.githubusercontent.com/74326345/236674172-e7fdb83c-5fd6-4f13-b5aa-ba27da20da49.gif) |
| Final Result | <img width="1312" alt="Screenshot 2023-05-07 at 4 22 58 PM" src="https://user-images.githubusercontent.com/74326345/236674175-4501a279-8727-4918-b36b-97dc0d33e818.png"> | 

</details> 

related #245