### PR TITLE
fix: replaced deprecated code with suggested ones

### DIFF
--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -500,7 +500,7 @@ void _updateInfoPlistFile({
   var elementFound = true;
   final uIStatusBarHidden = dict.children.whereType<XmlElement>().firstWhere(
     (element) {
-      return element.text == 'UIStatusBarHidden';
+      return element.innerText == 'UIStatusBarHidden';
     },
     orElse: () {
       final builder = XmlBuilder();
@@ -529,7 +529,7 @@ void _updateInfoPlistFile({
     final uIViewControllerBasedStatusBarAppearance =
         dict.children.whereType<XmlElement>().firstWhere(
       (element) {
-        return element.text == 'UIViewControllerBasedStatusBarAppearance';
+        return element.innerText == 'UIViewControllerBasedStatusBarAppearance';
       },
       orElse: () {
         final builder = XmlBuilder();


### PR DESCRIPTION
Using `XmlElement.innerText` instead of the deprecated `XmlElement.text`.

Tested that `text` should be replaced by `innerText` and not the `value` one.

<img width="813" alt="Screenshot 2023-05-14 at 8 53 21 PM" src="https://github.com/jonbhanson/flutter_native_splash/assets/74326345/9accd3bd-f427-4bb8-9aec-3ebfb905480b">
