### PR TITLE
fix: Don't expose string extension

### DIFF
--- a/lib/flavor_helper.dart
+++ b/lib/flavor_helper.dart
@@ -152,7 +152,7 @@ class _FlavorHelper {
   }
 }
 
-extension StringExtension on String {
+extension _StringExtension on String {
   String capitalize() {
     return "${this[0].toUpperCase()}${substring(1).toLowerCase()}";
   }


### PR DESCRIPTION
Do not expose the extension used for the package.
If you're not careful, you could use it in your code and make it dependent on the package.