### PR TITLE
(fix): web debug error - #622

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:flutter_native_splash/flutter_native_splash.dart';
 
 void main() {
   WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
+  FlutterNativeSplash.initWeb();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   runApp(const MyApp());
 }

--- a/lib/flutter_native_splash.dart
+++ b/lib/flutter_native_splash.dart
@@ -39,6 +39,12 @@ class FlutterNativeSplash {
 
   static WidgetsBinding? _widgetsBinding;
 
+  static void initWeb() {
+    if (kIsWeb) {
+      _channel.invokeMethod('show');
+    }
+  }
+
   // Prevents app from closing splash screen, app layout will be build but not displayed.
   static void preserve({required WidgetsBinding widgetsBinding}) {
     _widgetsBinding = widgetsBinding;

--- a/lib/flutter_native_splash_web.dart
+++ b/lib/flutter_native_splash_web.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_native_splash/remove_splash_from_web.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+
+import 'remove_splash_from_web.dart';
 // In order to *not* need this ignore, consider extracting the "web" version
 // of your plugin as a separate package, instead of inlining it in the same
 // package as the core of your plugin.
@@ -23,20 +25,32 @@ class FlutterNativeSplashWeb {
 
   Future<dynamic> handleMethodCall(MethodCall call) async {
     switch (call.method) {
-      case 'remove':
+      case 'show':
         try {
-          removeSplashFromWeb();
+          showSplashWeb();
         } catch (e) {
           throw Exception(
-            'Did you forget to run "dart run flutter_native_splash:create"? \n Could not run the JS command removeSplashFromWeb()',
+            'Did you forget to run "dart run flutter_native_splash:create"? \n Could not run the JS command showSplashWeb()',
+          );
+        }
+        return;
+      case 'remove':
+        try {
+          if (kDebugMode) {
+            hideSplashWeb();
+          } else {
+            removeSplashFromWeb();
+          }
+        } catch (e) {
+          throw Exception(
+            'Did you forget to run "dart run flutter_native_splash:create"? \n Could not run the JS command ${kDebugMode ? 'hideSplashWeb' : 'removeSplashFromWeb'}()${kDebugMode ? '\n\nOriginal error:\n$e' : ''}',
           );
         }
         return;
       default:
         throw PlatformException(
           code: 'Unimplemented',
-          details:
-              "flutter_native_splash for web doesn't implement '${call.method}'",
+          details: "flutter_native_splash for web doesn't implement '${call.method}'",
         );
     }
   }

--- a/lib/remove_splash_from_web.dart
+++ b/lib/remove_splash_from_web.dart
@@ -3,5 +3,14 @@ library remove_splash_from_web;
 
 import "package:js/js.dart";
 
+/// Defining the removeSplashFromWeb JavaScript function
 @JS("removeSplashFromWeb")
 external void removeSplashFromWeb();
+
+/// Defining the showSplashWeb JavaScript function
+@JS("showSplashWeb")
+external void showSplashWeb();
+
+/// Defining the hideSplashWeb JavaScript function
+@JS("hideSplashWeb")
+external void hideSplashWeb();

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -427,7 +427,7 @@ const String _webCss = '''
         -webkit-font-smoothing: antialiased;
     }
     
-    #splash.remove {
+    #splash.hide {
       /* enable click through when run animation */
       pointer-events: none;
       /* start animation */
@@ -511,13 +511,38 @@ const String _indexHtmlBrandingPicture = '''
 
 const String _webJS = '''
   <script id="splash-screen-script">
-    function removeSplashFromWeb() {
-      const splashElement = document.getElementById("splash");
-      splashElement.classList.add("remove");
+    function showSplashWeb(){
+      const splashElement = document.getElementById('splash');
+      if(splashElement.classList.contains('hide')) {
+        splashElement.style.display = 'block';
+        splashElement.classList.remove('hide');
+      }
+    }
+    
+    function hideSplashWeb(callback){
+      const splashElement = document.getElementById('splash');
+      splashElement.classList.add('hide');
       setTimeout(function () {
-        splashElement.remove();
-        document.getElementById("splash-screen-script")?.remove();
+        splashElement.style.display = 'none';
+      
+        if(typeof callback === 'function') {
+          callback();
+        } 
       }, [FADETIME] /* animation time + wait rendering and others(500ms) */);
+    }
+    
+    function removeSplashFromWeb(callback) {
+      hideSplashWeb(() => {
+        const splashElement = document.getElementById('splash');
+        splashElement.remove();
+        
+        document.getElementById('splash-screen-script')?.remove();      
+        document.getElementById('splash-screen-style')?.remove();
+        
+        if(typeof callback === 'function') {
+          callback();
+        } 
+      });
     }
   </script>
 ''';


### PR DESCRIPTION
Hello @jonbhanson,

Changes:
1. Added `initWeb` to `FlutterNativeSplash`.
2. Added the native JavaScript function `showSplashWeb` to `template.dart` and created a Dart function for it.
3. Added the native JavaScript function `hideSplashWeb` to `template.dart` and created a Dart function for it.
4. Refactored the JavaScript function `removeSplashFromWeb`.
5. Refactored the method `FlutterNativeSplashWeb.handleMethodCall`.

Why were these changes necessary?

In issue #607 (https://github.com/jonbhanson/flutter_native_splash/issues/607), I did not consider that it works with Flutter hot reload (at that time, there was a bug in the Android Studio Flutter plugin, and hot reload did not work). We cannot detect hot reload. However, it only occurs in debug mode, so by checking `kDebugMode`, we can determine if hot reload is running (assuming that it runs with hot reload in debug mode). In this case, we do not clean up the code from the HTML. We simply hide the overlay, and to prevent it from interfering at the end, we ensure this with `display=none`.

However, an additional step is needed in debug mode (side effect :( ). Therefore, `initWeb()` was introduced:
Usage:
```dart
WidgetsBinding widgetsBinding = WidgetsFlutterBinding.ensureInitialized();
FlutterNativeSplash.initWeb();
```
`WidgetsFlutterBinding.ensureInitialized()` must be called before invoking `FlutterNativeSplash.initWeb()`.

(Note: `initWeb` checks whether the Dart code is running on the web, so in the case of hybrid apps, the app using the library does not need to handle it separately.)