### PR TITLE
fix: exit process with error code when unexpected config provided in YAML

### DIFF
--- a/lib/cli_commands.dart
+++ b/lib/cli_commands.dart
@@ -368,7 +368,7 @@ Map<String, dynamic> _yamlToMap(YamlMap yamlMap) {
       print(pen("⚠️ The parameter \"${entry.key}\" was found "
           "in your flutter_native_splash config, but \"${entry.key}\" "
           "is not a valid flutter_native_splash parameter."));
-      exit(0);
+      exit(1);
     }
     if (entry.value is YamlList) {
       final list = <String>[];


### PR DESCRIPTION
### Current behavior:
- When provided invalid configuration in YAML for flutter_native_splash and ran `dart run flutter_native_splash:create` command, process exits with 0 code. This indicates process completed successfully without any issue.

### What's change:
- With this PR, the process exits with error code to indicate the command failed to get executed.

🐞 This PR fixes #656 .


---
### CI/CD pipeline wasn't failing before due to process completed with success code (`exit(0)`):
<img width="1092" alt="CI-CD-pipeline-before-change" src="https://github.com/jonbhanson/flutter_native_splash/assets/129262774/5c2c046b-812e-46b0-8139-95f5e40bcf2a">


### CI/CD pipeline fails with this PR changes because process now exits with error (`exit(1)`):
<img width="1096" alt="CI-CD-pipeline-after-change" src="https://github.com/jonbhanson/flutter_native_splash/assets/129262774/b37457b1-15b3-44f7-af09-859eb1b091d4">

