### PR TITLE
feat: support adjust padding bottom for branding image

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ flutter_native_splash:
   # To position the branding image at the bottom of the screen you can use bottom, bottomRight,
   # and bottomLeft. The default values is bottom if not specified or specified something else.
   #branding_mode: bottom
+  
+  # Set the branding padding from the bottom of the screen.  The default value is 0
+  # branding_bottom_padding: 24
 
   # The color_dark, background_image_dark, image_dark, branding_dark are parameters that set the background
   # and image when the device is in dark mode. If they are not specified, the app will use the
@@ -130,8 +133,10 @@ flutter_native_splash:
   #background_image_web: "assets/background-web.png"
   #background_image_dark_web: "assets/dark-background-web.png"
   #branding_android: assets/brand-android.png
+  #branding_bottom_padding_android: 24
   #branding_dark_android: assets/dart_dark-android.png
   #branding_ios: assets/brand-ios.png
+  #branding_bottom_padding_ios: 24
   #branding_dark_ios: assets/dart_dark-ios.png
   #branding_web: assets/brand-web.gif
   #branding_dark_web: assets/dart_dark-web.gif
@@ -289,6 +294,7 @@ flutter_native_splash:
   color: "#ffffff"
   image: assets/logo-acceptance.png
   branding: assets/branding-acceptance.png
+  branding_bottom_padding: 24
   color_dark: "#121212"
   image_dark: assets/logo-acceptance.png
   branding_dark: assets/branding-acceptance.png
@@ -306,6 +312,7 @@ flutter_native_splash:
   color: "#ffffff"
   image: assets/logo-production.png
   branding: assets/branding-production.png
+  branding_bottom_padding: 24
   color_dark: "#121212"
   image_dark: assets/logo-production.png
   branding_dark: assets/branding-production.png

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -56,6 +56,7 @@ void _createAndroidSplash({
   required String? android12BackgroundColor,
   required String? android12DarkBackgroundColor,
   required String? brandingImagePath,
+  required String? brandingBottomPadding,
   required String? brandingDarkImagePath,
   required String? color,
   required String? darkColor,
@@ -138,6 +139,7 @@ void _createAndroidSplash({
     showImage: imagePath != null,
     showBranding: brandingImagePath != null,
     brandingGravity: brandingGravity,
+    brandingBottomPadding: brandingBottomPadding,
   );
 
   if (darkColor != null || darkBackgroundImage != null) {
@@ -147,6 +149,7 @@ void _createAndroidSplash({
       showImage: imagePath != null,
       showBranding: brandingImagePath != null,
       brandingGravity: brandingGravity,
+      brandingBottomPadding: brandingBottomPadding,
     );
   }
 
@@ -157,6 +160,7 @@ void _createAndroidSplash({
       showImage: imagePath != null,
       showBranding: brandingImagePath != null,
       brandingGravity: brandingGravity,
+      brandingBottomPadding: brandingBottomPadding,
     );
     if (darkColor != null || darkBackgroundImage != null) {
       _applyLaunchBackgroundXml(
@@ -166,6 +170,7 @@ void _createAndroidSplash({
         showImage: imagePath != null,
         showBranding: brandingImagePath != null,
         brandingGravity: brandingGravity,
+        brandingBottomPadding: brandingBottomPadding,
       );
     }
   }
@@ -304,6 +309,7 @@ void _applyLaunchBackgroundXml({
   required String gravity,
   required bool showImage,
   bool showBranding = false,
+  String? brandingBottomPadding,
   String brandingGravity = 'bottom',
 }) {
   String brandingGravityValue = brandingGravity;
@@ -325,8 +331,11 @@ void _applyLaunchBackgroundXml({
 
   if (showBranding && gravity != brandingGravityValue) {
     //add branding when splash image and branding image are not at the same position
+    final androidRandingItemXml = _androidBrandingItemXml.replaceAll(
+        "{bottom_padding}", brandingBottomPadding ?? "0");
+    print('[Android] branding bottom padding: ${brandingBottomPadding ?? "0"}');
     final brandingItem =
-        XmlDocument.parse(_androidBrandingItemXml).rootElement.copy();
+        XmlDocument.parse(androidRandingItemXml).rootElement.copy();
     if (brandingGravityValue == 'bottomRight') {
       brandingGravityValue = 'bottom|right';
     } else if (brandingGravityValue == 'bottomLeft') {

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -331,11 +331,11 @@ void _applyLaunchBackgroundXml({
 
   if (showBranding && gravity != brandingGravityValue) {
     //add branding when splash image and branding image are not at the same position
-    final androidRandingItemXml = _androidBrandingItemXml.replaceAll(
+    final androidBrandingItemXml = _androidBrandingItemXml.replaceAll(
         "{bottom_padding}", brandingBottomPadding ?? "0");
     print('[Android] branding bottom padding: ${brandingBottomPadding ?? "0"}');
     final brandingItem =
-        XmlDocument.parse(androidRandingItemXml).rootElement.copy();
+        XmlDocument.parse(androidBrandingItemXml).rootElement.copy();
     if (brandingGravityValue == 'bottomRight') {
       brandingGravityValue = 'bottom|right';
     } else if (brandingGravityValue == 'bottomLeft') {

--- a/lib/cli_commands.dart
+++ b/lib/cli_commands.dart
@@ -64,10 +64,16 @@ void _createSplashByConfig(Map<String, dynamic> config) {
       _checkImageExists(config: config, parameter: _Parameter.darkImageWeb);
   final String? brandingImage =
       _checkImageExists(config: config, parameter: _Parameter.brandingImage);
+  final String? brandingBottomPadding =
+      config[_Parameter.brandingBottomPadding]?.toString();
   final String? brandingImageAndroid = _checkImageExists(
       config: config, parameter: _Parameter.brandingImageAndroid);
+  final String? brandingBottomPaddingAndroid =
+      config[_Parameter.brandingBottomPaddingAndroid]?.toString();
   final String? brandingImageIos =
       _checkImageExists(config: config, parameter: _Parameter.brandingImageIos);
+  final String? brandingBottomPaddingIos =
+      config[_Parameter.brandingBottomPaddingIos]?.toString();
   final String? brandingImageWeb =
       _checkImageExists(config: config, parameter: _Parameter.brandingImageWeb);
   final String? brandingDarkImage = _checkImageExists(
@@ -155,6 +161,8 @@ void _createSplashByConfig(Map<String, dynamic> config) {
         imagePath: imageAndroid ?? image,
         darkImagePath: darkImageAndroid ?? darkImage,
         brandingImagePath: brandingImageAndroid ?? brandingImage,
+        brandingBottomPadding:
+            brandingBottomPaddingAndroid ?? brandingBottomPadding,
         brandingDarkImagePath: brandingDarkImageAndroid ?? brandingDarkImage,
         backgroundImage: backgroundImageAndroid ?? backgroundImage,
         darkBackgroundImage: darkBackgroundImageAndroid ?? darkBackgroundImage,
@@ -189,6 +197,8 @@ void _createSplashByConfig(Map<String, dynamic> config) {
         darkBackgroundImage: darkBackgroundImageIos ?? darkBackgroundImage,
         brandingImagePath: brandingImageIos ?? brandingImage,
         brandingDarkImagePath: brandingDarkImageIos ?? brandingDarkImage,
+        brandingBottomPadding:
+            brandingBottomPaddingIos ?? brandingBottomPadding,
         color: colorIos ?? color,
         darkColor: darkColorIos ?? darkColor,
         plistFiles: plistFiles,
@@ -420,8 +430,11 @@ class _Parameter {
   static const brandingDarkImageWeb = 'branding_dark_web';
   static const brandingGravity = 'branding_mode';
   static const brandingImage = 'branding';
+  static const brandingBottomPadding = 'branding_bottom_padding';
   static const brandingImageAndroid = 'branding_android';
+  static const brandingBottomPaddingAndroid = 'branding_bottom_padding_android';
   static const brandingImageIos = 'branding_ios';
+  static const brandingBottomPaddingIos = 'branding_bottom_padding_ios';
   static const brandingImageWeb = 'branding_web';
   static const color = 'color';
   static const colorAndroid = "color_android";
@@ -467,8 +480,11 @@ class _Parameter {
     brandingDarkImageWeb,
     brandingGravity,
     brandingImage,
+    brandingBottomPadding,
     brandingImageAndroid,
     brandingImageIos,
+    brandingBottomPaddingIos,
+    brandingBottomPaddingAndroid,
     brandingImageWeb,
     color,
     colorAndroid,

--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -55,6 +55,7 @@ void _createiOSSplash({
   required String? imagePath,
   required String? darkImagePath,
   String? brandingImagePath,
+  String? brandingBottomPadding,
   String? brandingDarkImagePath,
   required String? color,
   required String? darkColor,
@@ -141,6 +142,7 @@ void _createiOSSplash({
     brandingImagePath: brandingImagePath,
     iosContentMode: iosContentMode,
     iosBrandingContentMode: iosBrandingContentMode,
+    brandingBottomPadding: brandingBottomPadding,
   );
   _createBackground(
     colorString: color,
@@ -209,6 +211,7 @@ void _updateLaunchScreenStoryboard({
   required String? imagePath,
   required String iosContentMode,
   String? brandingImagePath,
+  String? brandingBottomPadding,
   String? iosBrandingContentMode,
 }) {
   String? iosBrandingContentModeValue = iosBrandingContentMode;
@@ -376,7 +379,10 @@ void _updateLaunchScreenStoryboard({
     }
     final element = view.getElement('constraints');
 
-    final doc = XmlDocument.parse(toParse).rootElement.copy();
+    final toParseBottomPadding =
+        toParse.replaceAll("{bottom_padding}", brandingBottomPadding ?? "0");
+    print("[iOS] branding bottom padding: ${brandingBottomPadding ?? "0"}");
+    final doc = XmlDocument.parse(toParseBottomPadding).rootElement.copy();
     if (doc.firstChild != null) {
       print('[iOS] updating constraints with splash branding');
       for (final v in doc.children) {
@@ -396,6 +402,7 @@ void _createLaunchScreenStoryboard({
   required String iosContentMode,
   required String? iosBrandingContentMode,
   required String? brandingImagePath,
+  required String? brandingBottomPadding,
 }) {
   final file = File(_flavorHelper.iOSLaunchScreenStoryboardFile);
   file.createSync(recursive: true);
@@ -404,6 +411,7 @@ void _createLaunchScreenStoryboard({
   return _updateLaunchScreenStoryboard(
     imagePath: imagePath,
     brandingImagePath: brandingImagePath,
+    brandingBottomPadding: brandingBottomPadding,
     iosContentMode: iosContentMode,
     iosBrandingContentMode: iosBrandingContentMode,
   );

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -9,7 +9,7 @@ const String _androidLaunchItemXml = '''
 ''';
 
 const String _androidBrandingItemXml = '''
-    <item android:bottom="24dp">
+    <item android:bottom="{bottom_padding}dp">
         <bitmap android:gravity="center" android:src="@drawable/branding" />
     </item>
 ''';
@@ -386,21 +386,21 @@ const String _iOSLaunchBackgroundConstraints = '''
 const String _iOSBrandingCenterBottomConstraints = '''
 <constraints>
   <constraint firstItem="Uyq-Kz-ftE" firstAttribute="centerX" secondItem="YRO-k0-Ey4" secondAttribute="centerX" id="3kg-TC-cPP"/>
-  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="24" id="8Yb-q4-8bl"/>
+  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="{bottom_padding}" id="8Yb-q4-8bl"/>
 </constraints>
 ''';
 
 const String _iOSBrandingLeftBottomConstraints = '''
 <constraints>
   <constraint firstAttribute="leading" secondItem="Uyq-Kz-ftE" secondAttribute="leading" id="3kg-TC-cPP"/>
-  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="24" id="8Yb-q4-8bl"/>
+  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="{bottom_padding}" id="8Yb-q4-8bl"/>
 </constraints>
 ''';
 
 const String _iOSBrandingRightBottomConstraints = '''
 <constraints>
   <constraint firstAttribute="trailing" secondItem="Uyq-Kz-ftE" secondAttribute="trailing" id="3kg-TC-cPP"/>                            
-  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="24" id="8Yb-q4-8lb"/>                            
+  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="{bottom_padding}" id="8Yb-q4-8lb"/>                            
 </constraints>
 ''';
 

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -9,7 +9,7 @@ const String _androidLaunchItemXml = '''
 ''';
 
 const String _androidBrandingItemXml = '''
-    <item>
+    <item android:bottom="24dp">
         <bitmap android:gravity="center" android:src="@drawable/branding" />
     </item>
 ''';

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -386,21 +386,21 @@ const String _iOSLaunchBackgroundConstraints = '''
 const String _iOSBrandingCenterBottomConstraints = '''
 <constraints>
   <constraint firstItem="Uyq-Kz-ftE" firstAttribute="centerX" secondItem="YRO-k0-Ey4" secondAttribute="centerX" id="3kg-TC-cPP"/>
-  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom"  id="8Yb-q4-8bl"/>
+  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="24" id="8Yb-q4-8bl"/>
 </constraints>
 ''';
 
 const String _iOSBrandingLeftBottomConstraints = '''
 <constraints>
   <constraint firstAttribute="leading" secondItem="Uyq-Kz-ftE" secondAttribute="leading" id="3kg-TC-cPP"/>
-  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" id="8Yb-q4-8bl"/>
+  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="24" id="8Yb-q4-8bl"/>
 </constraints>
 ''';
 
 const String _iOSBrandingRightBottomConstraints = '''
 <constraints>
   <constraint firstAttribute="trailing" secondItem="Uyq-Kz-ftE" secondAttribute="trailing" id="3kg-TC-cPP"/>                            
-  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" id="8Yb-q4-8lb"/>                            
+  <constraint firstAttribute="bottom" secondItem="Uyq-Kz-ftE" secondAttribute="bottom" constant="24" id="8Yb-q4-8lb"/>                            
 </constraints>
 ''';
 


### PR DESCRIPTION
## What it does

- Support adding bottom padding for branding image regarding this issue https://github.com/jonbhanson/flutter_native_splash/issues/694

## How to test

1. follow this documentation to run and generate the native splash screen
2. enable branding image
3. add this config on your config yaml
```yaml
   branding_bottom_padding: 24

  #branding_bottom_padding_ios: 24 #specific config for iOS
  #branding_bottom_padding_android: 24 #specific config for Android
```
5. observe the branding image position

## Screenshot

## BEFORE
### iPhone 15 Pro Max
![image](https://github.com/jonbhanson/flutter_native_splash/assets/1531684/59813c6a-4be9-47fd-b281-9b0f433a8832)

### iPhone SE
![image](https://github.com/jonbhanson/flutter_native_splash/assets/1531684/a67d755f-38c0-4732-be7d-303449bbb8b1)

### < Android 13
![image](https://github.com/jonbhanson/flutter_native_splash/assets/1531684/afbf4be8-717f-41e1-a830-03e5fb628add)



## AFTER
#### iPhone 15 Pro Max 
![image](https://github.com/Lzyct/flutter_native_splash/assets/1531684/49ef6d58-8e45-49ac-9747-eb0a42e74a46)

### iPhone SE
![image](https://github.com/Lzyct/flutter_native_splash/assets/1531684/bc8238b2-c9e2-471d-8834-494fa049448d)

### < Android 13
![image](https://github.com/jonbhanson/flutter_native_splash/assets/1531684/212246f5-3ac4-4da6-970e-333e4404faea)
