### PR TITLE
Readme Update - Combining Effects with android_gravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ flutter_native_splash:
   # android_gravity can be one of the following Android Gravity (see
   # https://developer.android.com/reference/android/view/Gravity): bottom, center,
   # center_horizontal, center_vertical, clip_horizontal, clip_vertical, end, fill, fill_horizontal,
-  # fill_vertical, left, right, start, or top.
+  # fill_vertical, left, right, start, or top. android_gravity can be combined using the | operator to achieve multiple effects. 
+  # For example:
+  # `android_gravity: fill|clip_vertical` - This will fill the width while maintaining the image's vertical aspect ratio
   #android_gravity: center
   #
   # ios_content_mode can be one of the following iOS UIView.ContentMode (see


### PR DESCRIPTION
This documentation enhancement clarifies how to combine Android gravity flags for splash screen layouts, specifically addressing the common need to simultaneously fill and crop splash screen images. While this functionality exists in the underlying Android implementation, making it explicit in the Flutter documentation will help developers achieve better splash screen presentations without having to dive into platform-specific details:

> android_gravity can be combined using the | operator to achieve multiple effects. For example: android_gravity: fill|clip_vertical - This will fill the width while maintaining the image's vertical aspect ratio

This documentation update addresses a critical aspect of splash screen behavior on Android tablets, particularly devices like Amazon Fire tablets where aspect ratio handling is crucial for maintaining image quality. The ability to combine gravity flags provides developers with more precise control over splash screen presentation across different screen formats.