### PR TITLE
Fix viewport tag warning in flutter web

### DIFF
--- a/lib/web.dart
+++ b/lib/web.dart
@@ -345,17 +345,6 @@ void _updateHtml({
       )
       ?.remove();
 
-  // Add meta viewport if it doesn't exist
-  document.querySelector(
-        'meta[content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"][name="viewport"]',
-      ) ??
-      document.head?.append(
-        html_parser.parseFragment(
-          '  <meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport">\n',
-          container: '',
-        ),
-      );
-
   // Remove previously used src script tag (migrating to inline script)
   document
       .querySelector(


### PR DESCRIPTION
Flutter Web uses its own viewport configuration for better compatibility with Flutter.
and this tag should removed to avoid this warning in console

![image](https://github.com/user-attachments/assets/1b3f1b8e-3453-4340-9199-ed0c5563625b)
