### PR TITLE
feat: add ios background content mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,12 @@ flutter_native_splash:
   # `android_gravity: fill|clip_vertical` - This will fill the width while maintaining the image's vertical aspect ratio
   #android_gravity: center
   #
-  # ios_content_mode can be one of the following iOS UIView.ContentMode (see
+  # ios_content_mode and ios_background_content_mode can be one of the following iOS UIView.ContentMode (see
   # https://developer.apple.com/documentation/uikit/uiview/contentmode): scaleToFill,
   # scaleAspectFit, scaleAspectFill, center, top, bottom, left, right, topLeft, topRight,
   # bottomLeft, or bottomRight.
   #ios_content_mode: center
+  #ios_background_content_mode: scaleToFill
   #
   # web_image_mode can be one of the following modes: center, contain, stretch, and cover.
   #web_image_mode: center

--- a/lib/cli_commands.dart
+++ b/lib/cli_commands.dart
@@ -124,6 +124,8 @@ void _createSplashByConfig(Map<String, dynamic> config) {
   final bool fullscreen = config[_Parameter.fullscreen] as bool? ?? false;
   final String iosContentMode =
       config[_Parameter.iosContentMode] as String? ?? 'center';
+  final String iosBackgroundContentMode =
+      config[_Parameter.iosBackgroundContentMode] as String? ?? 'scaleToFill';
   final webImageMode = config[_Parameter.webImageMode] as String? ?? 'center';
   String? android12Image;
   String? android12DarkImage;
@@ -203,6 +205,7 @@ void _createSplashByConfig(Map<String, dynamic> config) {
         darkColor: darkColorIos ?? darkColor,
         plistFiles: plistFiles,
         iosContentMode: iosContentMode,
+        iosBackgroundContentMode: iosBackgroundContentMode,
         iosBrandingContentMode: brandingGravity,
         fullscreen: fullscreen,
       );
@@ -462,6 +465,7 @@ class _Parameter {
   static const imageWeb = 'image_web';
   static const ios = 'ios';
   static const iosContentMode = 'ios_content_mode';
+  static const iosBackgroundContentMode = 'ios_background_content_mode';
   static const plistFiles = 'info_plist_files';
   static const web = 'web';
   static const webImageMode = 'web_image_mode';
@@ -512,6 +516,7 @@ class _Parameter {
     imageWeb,
     ios,
     iosContentMode,
+    iosBackgroundContentMode,
     plistFiles,
     web,
     webImageMode,

--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -61,6 +61,7 @@ void _createiOSSplash({
   required String? darkColor,
   List<String>? plistFiles,
   required String iosContentMode,
+  String? iosBackgroundContentMode,
   String? iosBrandingContentMode,
   required bool fullscreen,
   required String? backgroundImage,
@@ -141,6 +142,7 @@ void _createiOSSplash({
     imagePath: imagePath,
     brandingImagePath: brandingImagePath,
     iosContentMode: iosContentMode,
+    iosBackgroundContentMode: iosBackgroundContentMode,
     iosBrandingContentMode: iosBrandingContentMode,
     brandingBottomPadding: brandingBottomPadding,
   );
@@ -210,6 +212,7 @@ void _applyImageiOS({
 void _updateLaunchScreenStoryboard({
   required String? imagePath,
   required String iosContentMode,
+  String? iosBackgroundContentMode,
   String? brandingImagePath,
   String? brandingBottomPadding,
   String? iosBrandingContentMode,
@@ -257,22 +260,25 @@ void _updateLaunchScreenStoryboard({
       exit(1);
     },
   );
-  subViews.children.whereType<XmlElement>().firstWhere(
+  final backgroundImageView = subViews.children.whereType<XmlElement>().firstWhere(
     (element) =>
         element.name.qualified == 'imageView' &&
         element.getAttribute('image') == _flavorHelper.iOSLaunchBackgroundName,
     orElse: () {
+      final backgroundSubView = XmlDocument.parse(_flavorHelper.iOSLaunchBackgroundSubView)
+          .rootElement
+          .copy();
+      backgroundSubView.setAttribute('contentMode', iosBackgroundContentMode);
       subViews.children.insert(
         0,
-        XmlDocument.parse(_flavorHelper.iOSLaunchBackgroundSubView)
-            .rootElement
-            .copy(),
+        backgroundSubView,
       );
       return XmlElement(XmlName(''));
     },
   );
   // Update the fill property
   imageView.setAttribute('contentMode', iosContentMode);
+  backgroundImageView.setAttribute('contentMode', iosBackgroundContentMode);
 
   if (!['bottom', 'bottomRight', 'bottomLeft']
       .contains(iosBrandingContentModeValue)) {
@@ -400,6 +406,7 @@ void _updateLaunchScreenStoryboard({
 void _createLaunchScreenStoryboard({
   required String? imagePath,
   required String iosContentMode,
+  required String? iosBackgroundContentMode,
   required String? iosBrandingContentMode,
   required String? brandingImagePath,
   required String? brandingBottomPadding,
@@ -413,6 +420,7 @@ void _createLaunchScreenStoryboard({
     brandingImagePath: brandingImagePath,
     brandingBottomPadding: brandingBottomPadding,
     iosContentMode: iosContentMode,
+    iosBackgroundContentMode: iosBackgroundContentMode,
     iosBrandingContentMode: iosBrandingContentMode,
   );
 }


### PR DESCRIPTION
Currently, iOS Content Mode for LaunchBackground is always set to "Scale To Fill".
I think it would be nice to be able to set it to other content mode, so added "ios_background_content_mode" parameter.