### PR TITLE
Introduce min Android SDK parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ flutter_native_splash:
   # https://developer.android.com/guide/topics/manifest/activity-element#screen
   #android_screen_orientation: sensorLandscape
 
+  # By specifying the used minimum SDK version of Android, flutter_native_splash might be able to
+  # merge/remove certain styles and drawables.
+  #android_min_sdk: 24  # default 16
+
   # hide notif bar on android. ios already hides it by default. 
   # Has no effect in web since web has no notification bar.
   fullscreen: true                # default false

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -70,7 +70,33 @@ void _createAndroidSplash({
   required String? screenOrientation,
   String? android12BrandingImagePath,
   String? android12DarkBrandingImagePath,
+  int? androidMinSdk,
 }) {
+  androidMinSdk ??= 16;
+  final androidDrawableFolder =
+      _flavorHelper.getAndroidDrawableFolder(androidMinSdk);
+  final androidNightDrawableFolder =
+      _flavorHelper.getAndroidNightDrawableFolder(androidMinSdk);
+  final androidLaunchBackgroundFile =
+      _flavorHelper.getAndroidLaunchBackgroundFile(androidMinSdk);
+  final androidLaunchDarkBackgroundFile =
+      _flavorHelper.getAndroidLaunchDarkBackgroundFile(androidMinSdk);
+  final androidStylesFile = _flavorHelper.getAndroidStylesFile(androidMinSdk);
+  final androidNightStylesFile =
+      _flavorHelper.getAndroidNightStylesFile(androidMinSdk);
+  final androidV31StylesFile =
+      _flavorHelper.getAndroidV31StylesFile(androidMinSdk);
+  final androidV31NightStylesFile =
+      _flavorHelper.getAndroidV31NightStylesFile(androidMinSdk);
+  final androidV21DrawableFolder =
+      _flavorHelper.getAndroidV21DrawableFolder(androidMinSdk);
+  final androidV21LaunchBackgroundFile =
+      _flavorHelper.getAndroidV21LaunchBackgroundFile(androidMinSdk);
+  final androidNightV21DrawableFolder =
+      _flavorHelper.getAndroidNightV21DrawableFolder(androidMinSdk);
+  final androidV21LaunchDarkBackgroundFile =
+      _flavorHelper.getAndroidV21LaunchDarkBackgroundFile(androidMinSdk);
+
   _applyImageAndroid(imagePath: imagePath);
 
   _applyImageAndroid(imagePath: darkImagePath, dark: true);
@@ -109,44 +135,38 @@ void _createAndroidSplash({
     fileName: 'android12branding.png',
   );
 
-  _createBackground(
-    colorString: color,
-    darkColorString: darkColor,
-    darkBackgroundImageSource: darkBackgroundImage,
-    backgroundImageSource: backgroundImage,
-    darkBackgroundImageDestination:
-        '${_flavorHelper.androidNightDrawableFolder}background.png',
-    backgroundImageDestination:
-        '${_flavorHelper.androidDrawableFolder}background.png',
-  );
+  if (androidNightDrawableFolder != null && androidDrawableFolder != null) {
+    _createBackground(
+      colorString: color,
+      darkColorString: darkColor,
+      darkBackgroundImageSource: darkBackgroundImage,
+      backgroundImageSource: backgroundImage,
+      darkBackgroundImageDestination:
+          '${androidNightDrawableFolder}background.png',
+      backgroundImageDestination: '${androidDrawableFolder}background.png',
+    );
+  }
 
-  _createBackground(
-    colorString: color,
-    darkColorString: darkColor,
-    darkBackgroundImageSource: darkBackgroundImage,
-    backgroundImageSource: backgroundImage,
-    darkBackgroundImageDestination:
-        '${_flavorHelper.androidNightV21DrawableFolder}background.png',
-    backgroundImageDestination:
-        '${_flavorHelper.androidV21DrawableFolder}background.png',
-  );
+  if (androidNightV21DrawableFolder != null &&
+      androidV21DrawableFolder != null) {
+    _createBackground(
+      colorString: color,
+      darkColorString: darkColor,
+      darkBackgroundImageSource: darkBackgroundImage,
+      backgroundImageSource: backgroundImage,
+      darkBackgroundImageDestination:
+          '${androidNightV21DrawableFolder}background.png',
+      backgroundImageDestination: '${androidV21DrawableFolder}background.png',
+    );
+  }
 
   // ignore_for_file: avoid_print
   print('[Android] Updating launch background(s) with splash image path...');
 
-  _applyLaunchBackgroundXml(
-    gravity: gravity,
-    launchBackgroundFilePath: _flavorHelper.androidLaunchBackgroundFile,
-    showImage: imagePath != null,
-    showBranding: brandingImagePath != null,
-    brandingGravity: brandingGravity,
-    brandingBottomPadding: brandingBottomPadding,
-  );
-
-  if (darkColor != null || darkBackgroundImage != null) {
+  if (androidLaunchBackgroundFile != null) {
     _applyLaunchBackgroundXml(
       gravity: gravity,
-      launchBackgroundFilePath: _flavorHelper.androidLaunchDarkBackgroundFile,
+      launchBackgroundFilePath: androidLaunchBackgroundFile,
       showImage: imagePath != null,
       showBranding: brandingImagePath != null,
       brandingGravity: brandingGravity,
@@ -154,20 +174,34 @@ void _createAndroidSplash({
     );
   }
 
-  if (Directory(_flavorHelper.androidV21DrawableFolder).existsSync()) {
+  if (androidLaunchDarkBackgroundFile != null &&
+      (darkColor != null || darkBackgroundImage != null)) {
     _applyLaunchBackgroundXml(
       gravity: gravity,
-      launchBackgroundFilePath: _flavorHelper.androidV21LaunchBackgroundFile,
+      launchBackgroundFilePath: androidLaunchDarkBackgroundFile,
       showImage: imagePath != null,
       showBranding: brandingImagePath != null,
       brandingGravity: brandingGravity,
       brandingBottomPadding: brandingBottomPadding,
     );
-    if (darkColor != null || darkBackgroundImage != null) {
+  }
+
+  if (androidV21DrawableFolder != null &&
+      androidV21LaunchBackgroundFile != null &&
+      Directory(androidV21DrawableFolder).existsSync()) {
+    _applyLaunchBackgroundXml(
+      gravity: gravity,
+      launchBackgroundFilePath: androidV21LaunchBackgroundFile,
+      showImage: imagePath != null,
+      showBranding: brandingImagePath != null,
+      brandingGravity: brandingGravity,
+      brandingBottomPadding: brandingBottomPadding,
+    );
+    if (androidV21LaunchDarkBackgroundFile != null &&
+        (darkColor != null || darkBackgroundImage != null)) {
       _applyLaunchBackgroundXml(
         gravity: gravity,
-        launchBackgroundFilePath:
-            _flavorHelper.androidV21LaunchDarkBackgroundFile,
+        launchBackgroundFilePath: androidV21LaunchDarkBackgroundFile,
         showImage: imagePath != null,
         showBranding: brandingImagePath != null,
         brandingGravity: brandingGravity,
@@ -177,37 +211,45 @@ void _createAndroidSplash({
   }
 
   print('[Android] Updating styles...');
-  _applyStylesXml(
-    fullScreen: fullscreen,
-    file: _flavorHelper.androidV31StylesFile,
-    template: _androidV31StylesXml,
-    android12BackgroundColor: android12BackgroundColor,
-    android12ImagePath: android12ImagePath,
-    android12IconBackgroundColor: android12IconBackgroundColor,
-    android12BrandingImagePath: android12BrandingImagePath,
-  );
+  if (androidV31StylesFile != null) {
+    _applyStylesXml(
+      fullScreen: fullscreen,
+      file: androidV31StylesFile,
+      template: _androidV31StylesXml,
+      android12BackgroundColor: android12BackgroundColor,
+      android12ImagePath: android12ImagePath,
+      android12IconBackgroundColor: android12IconBackgroundColor,
+      android12BrandingImagePath: android12BrandingImagePath,
+    );
+  }
 
-  _applyStylesXml(
-    fullScreen: fullscreen,
-    file: _flavorHelper.androidV31StylesNightFile,
-    template: _androidV31StylesNightXml,
-    android12BackgroundColor: android12DarkBackgroundColor,
-    android12ImagePath: android12DarkImagePath,
-    android12IconBackgroundColor: darkAndroid12IconBackgroundColor,
-    android12BrandingImagePath: android12DarkBrandingImagePath,
-  );
+  if (androidV31NightStylesFile != null) {
+    _applyStylesXml(
+      fullScreen: fullscreen,
+      file: androidV31NightStylesFile,
+      template: _androidV31StylesNightXml,
+      android12BackgroundColor: android12DarkBackgroundColor,
+      android12ImagePath: android12DarkImagePath,
+      android12IconBackgroundColor: darkAndroid12IconBackgroundColor,
+      android12BrandingImagePath: android12DarkBrandingImagePath,
+    );
+  }
 
-  _applyStylesXml(
-    fullScreen: fullscreen,
-    file: _flavorHelper.androidStylesFile,
-    template: _androidStylesXml,
-  );
+  if (androidStylesFile != null) {
+    _applyStylesXml(
+      fullScreen: fullscreen,
+      file: androidStylesFile,
+      template: _androidStylesXml,
+    );
+  }
 
-  _applyStylesXml(
-    fullScreen: fullscreen,
-    file: _flavorHelper.androidNightStylesFile,
-    template: _androidStylesNightXml,
-  );
+  if (androidNightStylesFile != null) {
+    _applyStylesXml(
+      fullScreen: fullscreen,
+      file: androidNightStylesFile,
+      template: _androidStylesNightXml,
+    );
+  }
 
   _applyOrientation(orientation: screenOrientation);
 }

--- a/lib/android.dart
+++ b/lib/android.dart
@@ -92,8 +92,8 @@ void _createAndroidSplash({
       _flavorHelper.getAndroidV21DrawableFolder(androidMinSdk);
   final androidV21LaunchBackgroundFile =
       _flavorHelper.getAndroidV21LaunchBackgroundFile(androidMinSdk);
-  final androidNightV21DrawableFolder =
-      _flavorHelper.getAndroidNightV21DrawableFolder(androidMinSdk);
+  final androidV21NightDrawableFolder =
+      _flavorHelper.getAndroidV21NightDrawableFolder(androidMinSdk);
   final androidV21LaunchDarkBackgroundFile =
       _flavorHelper.getAndroidV21LaunchDarkBackgroundFile(androidMinSdk);
 
@@ -147,7 +147,7 @@ void _createAndroidSplash({
     );
   }
 
-  if (androidNightV21DrawableFolder != null &&
+  if (androidV21NightDrawableFolder != null &&
       androidV21DrawableFolder != null) {
     _createBackground(
       colorString: color,
@@ -155,7 +155,7 @@ void _createAndroidSplash({
       darkBackgroundImageSource: darkBackgroundImage,
       backgroundImageSource: backgroundImage,
       darkBackgroundImageDestination:
-          '${androidNightV21DrawableFolder}background.png',
+          '${androidV21NightDrawableFolder}background.png',
       backgroundImageDestination: '${androidV21DrawableFolder}background.png',
     );
   }

--- a/lib/cli_commands.dart
+++ b/lib/cli_commands.dart
@@ -120,6 +120,7 @@ void _createSplashByConfig(Map<String, dynamic> config) {
   }
   final String? androidScreenOrientation =
       config[_Parameter.androidScreenOrientation] as String?;
+  final int? androidMinSdk = config[_Parameter.androidMinSdk] as int?;
   final brandingGravity =
       config[_Parameter.brandingGravity] as String? ?? 'bottom';
   final bool fullscreen = config[_Parameter.fullscreen] as bool? ?? false;
@@ -173,6 +174,7 @@ void _createSplashByConfig(Map<String, dynamic> config) {
         brandingGravity: brandingGravity,
         fullscreen: fullscreen,
         screenOrientation: androidScreenOrientation,
+        androidMinSdk: androidMinSdk,
         android12ImagePath: android12Image,
         android12DarkImagePath: android12DarkImage ?? android12Image,
         android12BackgroundColor: android12Color,
@@ -420,6 +422,7 @@ String? parseColor(dynamic color) {
 class _Parameter {
   static const android = 'android';
   static const android12Section = 'android_12';
+  static const androidMinSdk = 'android_min_sdk';
   static const androidScreenOrientation = 'android_screen_orientation';
   static const backgroundImage = 'background_image';
   static const backgroundImageAndroid = 'background_image_android';
@@ -470,6 +473,7 @@ class _Parameter {
   static List<String> all = [
     android,
     android12Section,
+    androidMinSdk,
     androidScreenOrientation,
     backgroundImage,
     backgroundImageAndroid,

--- a/lib/flavor_helper.dart
+++ b/lib/flavor_helper.dart
@@ -71,6 +71,60 @@ class _FlavorHelper {
     return '${androidNightV21DrawableFolder}launch_background.xml';
   }
 
+  String? getAndroidDrawableFolder(int minSdk) {
+    return minSdk < 21 ? androidDrawableFolder : null;
+  }
+
+  String? getAndroidNightDrawableFolder(int minSdk) {
+    return minSdk < 21 ? androidNightDrawableFolder : null;
+  }
+
+  String? getAndroidLaunchBackgroundFile(int minSdk) {
+    return minSdk < 21 ? androidLaunchBackgroundFile : null;
+  }
+
+  String? getAndroidLaunchDarkBackgroundFile(int minSdk) {
+    return minSdk < 21 ? androidLaunchDarkBackgroundFile : null;
+  }
+
+  String? getAndroidStylesFile(int minSdk) {
+    return minSdk < 31 ? androidStylesFile : null;
+  }
+
+  String? getAndroidNightStylesFile(int minSdk) {
+    return minSdk < 31 ? androidNightStylesFile : null;
+  }
+
+  String? getAndroidV31StylesFile(int minSdk) {
+    return minSdk < 31 ? androidV31StylesFile : androidStylesFile;
+  }
+
+  String? getAndroidV31NightStylesFile(int minSdk) {
+    return minSdk < 31 ? androidV31StylesNightFile : androidNightStylesFile;
+  }
+
+  String? getAndroidV21DrawableFolder(int minSdk) {
+    return minSdk < 21 ? androidV21DrawableFolder : androidDrawableFolder;
+  }
+
+  String? getAndroidV21LaunchBackgroundFile(int minSdk) {
+    return minSdk < 21
+        ? androidV21LaunchBackgroundFile
+        : androidLaunchBackgroundFile;
+  }
+
+  String? getAndroidNightV21DrawableFolder(int minSdk) {
+    return minSdk < 21
+        ? androidNightV21DrawableFolder
+        : androidNightDrawableFolder;
+  }
+
+  String? getAndroidV21LaunchDarkBackgroundFile(int minSdk) {
+    return minSdk < 21
+        ? androidV21LaunchDarkBackgroundFile
+        : androidLaunchDarkBackgroundFile;
+  }
+
   String get androidManifestFile {
     return 'android/app/src/main/AndroidManifest.xml';
   }

--- a/lib/flavor_helper.dart
+++ b/lib/flavor_helper.dart
@@ -113,7 +113,7 @@ class _FlavorHelper {
         : androidLaunchBackgroundFile;
   }
 
-  String? getAndroidNightV21DrawableFolder(int minSdk) {
+  String? getAndroidV21NightDrawableFolder(int minSdk) {
     return minSdk < 21
         ? androidNightV21DrawableFolder
         : androidNightDrawableFolder;


### PR DESCRIPTION
I got the inspiration for this when thinking about `flutter_launcher_icons`'s `min_sdk_android` parameter and seeing the v21 and v31 folders that `flutter_native_splash` generates.
If the used `minSdkVersion` is already 21 or higher, the "default" drawable[-night] folders are redundant as they will not be used anyway. Likewise, if the `minSdkVersion` is 31 or higher, the values[-night] folders are redundant.
This PR tries to get rid of these redundant/unneeded files by simply not generating these configurations and generating the "newer" configurations in their place.
Not the cleanest piece of code, sadly - so I am open for suggestions, of course! :)