### PR TITLE
fix: remove command always showing help instead of executing

### DIFF
--- a/bin/remove.dart
+++ b/bin/remove.dart
@@ -25,9 +25,9 @@ void main(List<String> args) {
 
   final parsedArgs = parser.parse(args);
 
-  final helpArg = parsedArgs[ArgEnums.help.name];
+  final helpArg = parsedArgs[ArgEnums.help.name] as bool?;
 
-  if (helpArg != null) {
+  if (helpArg == true) {
     // ignore_for_file: avoid_print
     print(parser.usage);
     return;


### PR DESCRIPTION
The help flag check used `helpArg != null` but addFlag always returns a bool (false when not specified), never null. This caused the remove command to always print help and exit without executing.

Changed to `helpArg == true` to match the same pattern used in create.dart.

Fixes #822, Fixes #804, Fixes #786## Problem

The `dart run flutter_native_splash:remove` command has been broken since PR #752. Instead of executing the removal, it always prints help text and exits.

## Root Cause

In `bin/remove.dart`, the help flag check uses `helpArg != null`. However, `addFlag` always returns a `bool` (`false` when not specified), never `null`. So the condition is always `true`, causing the command to print help and return early every time.

```dart
// Bug: always true because addFlag returns false, not null
if (helpArg != null) { ... }

// Fix: matches the pattern already used in create.dart
if (helpArg == true) { ... }
```

## Changes

- Changed `helpArg != null` to `helpArg == true` in `bin/remove.dart`
- - Added `as bool?` type cast to match `create.dart` style
## Verification

- `dart analyze` passes with no issues
- - All 11 existing tests pass
- - Confirmed with a test script that `addFlag` returns `bool`, never `null`
Fixes #822, Fixes #804, Fixes #786