### PR TITLE
chore: minor housekeeping - format, ci update, more tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: subosito/flutter-action@v2
       - name: Install Dependencies
         run: flutter pub get

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
       - name: Install Dependencies
         run: flutter pub get

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -129,9 +129,7 @@ class _MyHomePageState extends State<MyHomePage> {
           // wireframe for each widget.
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
+            const Text('You have pushed the button this many times:'),
             Text(
               '$_counter',
               style: Theme.of(context).textTheme.headlineMedium,

--- a/test/flutter_native_splash_test.dart
+++ b/test/flutter_native_splash_test.dart
@@ -5,12 +5,32 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:path/path.dart' as p;
 
 void main() {
-  test('parseColor parses values correctly', () {
-    expect(parseColor('#ffffff'), 'ffffff');
-    expect(parseColor(' FAFAFA '), 'FAFAFA');
-    expect(parseColor('121212'), '121212');
-    expect(parseColor(null), null);
-    expect(() => parseColor('badcolor'), throwsException);
+  group('parseColor', () {
+    test('parses string values correctly', () {
+      expect(parseColor('#ffffff'), 'ffffff');
+      expect(parseColor(' FAFAFA '), 'FAFAFA');
+      expect(parseColor('121212'), '121212');
+      expect(parseColor('#000000'), '000000');
+      expect(parseColor('F9E524'), 'F9E524');
+    });
+
+    test('returns null for null input', () {
+      expect(parseColor(null), null);
+    });
+
+    test('throws for invalid color strings', () {
+      expect(() => parseColor('badcolor'), throwsException);
+      expect(() => parseColor('#12345'), throwsException);
+      expect(() => parseColor('1234567'), throwsException);
+      expect(() => parseColor(''), throwsException);
+    });
+
+    test('handles integer values from YAML parsing', () {
+      // YAML parses unquoted numeric values like 000000 as int 0
+      expect(parseColor(0), '000000');
+      // YAML parses 123456 as int
+      expect(parseColor(123456), '123456');
+    });
   });
 
   group('config file from args', () {


### PR DESCRIPTION
Hey! Just some small cleanup while going through the codebase:

- **Code formatting**: `example/lib/main.dart` had a minor formatting issue caught by `dart format`
- **CI**: bumped `actions/checkout` from v2 to v4 (v2 has been deprecated by GitHub)
- **Tests**: expanded `parseColor` tests with more edge cases — int inputs from YAML, invalid strings, null handling, etc.

Nothing fancy, just keeping things tidy.