### PR TITLE
feat: support anchored ios_content_mode syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ flutter_native_splash:
   #ios_content_mode: center      # scaleToFill, scaleAspectFit, scaleAspectFill, 
   # center, top, bottom, left, right, topLeft, topRight, bottomLeft, or bottomRight.
   # visit https://developer.apple.com/documentation/uikit/uiview/contentmode
+  # You can combine scaleAspectFit or scaleAspectFill with an anchor, for example:
+  #ios_content_mode: scaleAspectFit|top
+  #ios_content_mode: scaleAspectFill|bottomRight
   #web_image_mode: center        # center, contain, stretch, cover
 
   # general branding for all platform (except android 12+):

--- a/lib/ios.dart
+++ b/lib/ios.dart
@@ -215,7 +215,18 @@ void _updateLaunchScreenStoryboard({
   String? brandingBottomPadding,
   String? iosBrandingContentMode,
 }) {
+  final parsedIosContentMode = _parseIosContentMode(iosContentMode);
   String? iosBrandingContentModeValue = iosBrandingContentMode;
+  Image? splashImage;
+
+  if (imagePath != null) {
+    splashImage = decodeImage(File(imagePath).readAsBytesSync());
+    if (splashImage == null) {
+      print('$imagePath could not be loaded.');
+      exit(1);
+    }
+  }
+
   // Load the data
   final file = File(_flavorHelper.iOSLaunchScreenStoryboardFile);
   final xmlDocument = XmlDocument.parse(file.readAsStringSync());
@@ -273,7 +284,7 @@ void _updateLaunchScreenStoryboard({
     },
   );
   // Update the fill property
-  imageView.setAttribute('contentMode', iosContentMode);
+  imageView.setAttribute('contentMode', parsedIosContentMode.contentMode);
 
   if (!['bottom', 'bottomRight', 'bottomLeft']
       .contains(iosBrandingContentModeValue)) {
@@ -334,18 +345,22 @@ void _updateLaunchScreenStoryboard({
   );
 
   view.children.remove(view.getElement('constraints'));
+  final String constraints = parsedIosContentMode.anchor != null &&
+          splashImage != null
+      ? _buildLaunchBackgroundConstraintsWithAnchor(
+          contentMode: parsedIosContentMode.contentMode,
+          anchor: parsedIosContentMode.anchor!,
+          imageWidth: splashImage.width,
+          imageHeight: splashImage.height,
+        )
+      : _iOSLaunchBackgroundConstraints;
   view.children.add(
-    XmlDocument.parse(_iOSLaunchBackgroundConstraints).rootElement.copy(),
+    XmlDocument.parse(constraints).rootElement.copy(),
   );
 
-  if (imagePath != null) {
-    final image = decodeImage(File(imagePath).readAsBytesSync());
-    if (image == null) {
-      print('$imagePath could not be loaded.');
-      exit(1);
-    }
-    launchImageResource?.setAttribute('width', image.width.toString());
-    launchImageResource?.setAttribute('height', image.height.toString());
+  if (splashImage != null) {
+    launchImageResource?.setAttribute('width', splashImage.width.toString());
+    launchImageResource?.setAttribute('height', splashImage.height.toString());
   }
 
   if (brandingImagePath != null) {
@@ -395,6 +410,150 @@ void _updateLaunchScreenStoryboard({
   file.writeAsStringSync(
     '${xmlDocument.toXmlString(pretty: true, indent: '    ')}\n',
   );
+}
+
+class _IosContentModeConfig {
+  final String contentMode;
+  final String? anchor;
+
+  _IosContentModeConfig({
+    required this.contentMode,
+    this.anchor,
+  });
+}
+
+_IosContentModeConfig _parseIosContentMode(String iosContentMode) {
+  final trimmed = iosContentMode.trim();
+
+  if (!trimmed.contains('|')) {
+    return _IosContentModeConfig(
+      contentMode: _canonicalIosContentMode(trimmed),
+    );
+  }
+
+  final separatorIndex = trimmed.indexOf('|');
+  final modeToken = trimmed.substring(0, separatorIndex).trim();
+  final anchorToken = trimmed.substring(separatorIndex + 1).trim();
+  final canonicalMode = _canonicalIosContentMode(modeToken);
+  final anchor = _normalizeIosAnchor(anchorToken);
+
+  final bool supportsAnchors =
+      canonicalMode == 'scaleAspectFit' || canonicalMode == 'scaleAspectFill';
+  if (supportsAnchors && anchor != null) {
+    return _IosContentModeConfig(
+      contentMode: canonicalMode,
+      anchor: anchor,
+    );
+  }
+
+  if (supportsAnchors && anchor == null) {
+    print(
+      '[iOS] Unsupported anchor "$anchorToken" in ios_content_mode. '
+      'Supported anchors: center, top, bottom, left, right, '
+      'topLeft, topRight, bottomLeft, bottomRight.',
+    );
+  }
+
+  return _IosContentModeConfig(contentMode: canonicalMode);
+}
+
+String _canonicalIosContentMode(String value) {
+  final normalized = value.toLowerCase().replaceAll(RegExp(r'[\s_-]'), '');
+  switch (normalized) {
+    case 'scaletofill':
+      return 'scaleToFill';
+    case 'scaleaspectfit':
+      return 'scaleAspectFit';
+    case 'scaleaspectfill':
+      return 'scaleAspectFill';
+    case 'center':
+      return 'center';
+    case 'top':
+      return 'top';
+    case 'bottom':
+      return 'bottom';
+    case 'left':
+      return 'left';
+    case 'right':
+      return 'right';
+    case 'topleft':
+      return 'topLeft';
+    case 'topright':
+      return 'topRight';
+    case 'bottomleft':
+      return 'bottomLeft';
+    case 'bottomright':
+      return 'bottomRight';
+    default:
+      return value;
+  }
+}
+
+String? _normalizeIosAnchor(String value) {
+  final normalized = value.toLowerCase().replaceAll(RegExp(r'[\s_-]'), '');
+  switch (normalized) {
+    case 'center':
+      return 'center';
+    case 'top':
+      return 'top';
+    case 'bottom':
+      return 'bottom';
+    case 'left':
+      return 'left';
+    case 'right':
+      return 'right';
+    case 'topleft':
+      return 'topLeft';
+    case 'topright':
+      return 'topRight';
+    case 'bottomleft':
+      return 'bottomLeft';
+    case 'bottomright':
+      return 'bottomRight';
+    default:
+      return null;
+  }
+}
+
+String _buildLaunchBackgroundConstraintsWithAnchor({
+  required String contentMode,
+  required String anchor,
+  required int imageWidth,
+  required int imageHeight,
+}) {
+  final relation = contentMode == 'scaleAspectFill'
+      ? 'greaterThanOrEqual'
+      : 'lessThanOrEqual';
+
+  final bool isLeftAligned = anchor == 'left' ||
+      anchor == 'topLeft' ||
+      anchor == 'bottomLeft';
+  final bool isRightAligned = anchor == 'right' ||
+      anchor == 'topRight' ||
+      anchor == 'bottomRight';
+  final bool isTopAligned =
+      anchor == 'top' || anchor == 'topLeft' || anchor == 'topRight';
+  final bool isBottomAligned =
+      anchor == 'bottom' || anchor == 'bottomLeft' || anchor == 'bottomRight';
+
+  final horizontalConstraint = isLeftAligned
+      ? _iOSLaunchImageHorizontalLeadingConstraint
+      : isRightAligned
+          ? _iOSLaunchImageHorizontalTrailingConstraint
+          : _iOSLaunchImageHorizontalCenterConstraint;
+
+  final verticalConstraint = isTopAligned
+      ? _iOSLaunchImageVerticalTopConstraint
+      : isBottomAligned
+          ? _iOSLaunchImageVerticalBottomConstraint
+          : _iOSLaunchImageVerticalCenterConstraint;
+
+  return _iOSLaunchBackgroundAnchoredConstraints
+      .replaceAll('[HORIZONTAL_CONSTRAINT]', horizontalConstraint)
+      .replaceAll('[VERTICAL_CONSTRAINT]', verticalConstraint)
+      .replaceAll('[IMAGE_HEIGHT]', imageHeight.toString())
+      .replaceAll('[IMAGE_WIDTH]', imageWidth.toString())
+      .replaceAll('[RELATION]', relation);
 }
 
 /// Creates LaunchScreen.storyboard with splash image path

--- a/lib/templates.dart
+++ b/lib/templates.dart
@@ -383,6 +383,40 @@ const String _iOSLaunchBackgroundConstraints = '''
 </constraints>
 ''';
 
+const String _iOSLaunchBackgroundAnchoredConstraints = '''
+<constraints>
+  [HORIZONTAL_CONSTRAINT]
+  [VERTICAL_CONSTRAINT]
+  <constraint firstItem="YRO-k0-Ey4" firstAttribute="height" secondItem="YRO-k0-Ey4" secondAttribute="width" multiplier="[IMAGE_HEIGHT]:[IMAGE_WIDTH]" id="A0i-OJ-jvQ"/>
+  <constraint firstItem="YRO-k0-Ey4" firstAttribute="width" secondItem="Ze5-6b-2t3" secondAttribute="width" relation="[RELATION]" id="Yvb-jT-CaE"/>
+  <constraint firstItem="YRO-k0-Ey4" firstAttribute="height" secondItem="Ze5-6b-2t3" secondAttribute="height" relation="[RELATION]" id="7Sc-BN-WV5"/>
+  <constraint firstItem="YRO-k0-Ey4" firstAttribute="width" secondItem="Ze5-6b-2t3" secondAttribute="width" priority="750" id="S8n-mp-2UQ"/>
+  <constraint firstItem="YRO-k0-Ey4" firstAttribute="height" secondItem="Ze5-6b-2t3" secondAttribute="height" priority="750" id="TFv-a4-eRM"/>
+  <constraint firstItem="tWc-Dq-wcI" firstAttribute="bottom" secondItem="Ze5-6b-2t3" secondAttribute="bottom" id="RPx-PI-7Xg"/>
+  <constraint firstItem="tWc-Dq-wcI" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="SdS-ul-q2q"/>
+  <constraint firstAttribute="trailing" secondItem="tWc-Dq-wcI" secondAttribute="trailing" id="Swv-Gf-Rwn"/>
+  <constraint firstItem="tWc-Dq-wcI" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="kV7-tw-vXt"/>
+</constraints>
+''';
+
+const String _iOSLaunchImageHorizontalLeadingConstraint =
+    '<constraint firstItem="YRO-k0-Ey4" firstAttribute="leading" secondItem="Ze5-6b-2t3" secondAttribute="leading" id="iOa-x7-RaF"/>';
+
+const String _iOSLaunchImageHorizontalCenterConstraint =
+    '<constraint firstItem="YRO-k0-Ey4" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="1a2-6s-vTC"/>';
+
+const String _iOSLaunchImageHorizontalTrailingConstraint =
+    '<constraint firstAttribute="trailing" secondItem="YRO-k0-Ey4" secondAttribute="trailing" id="2gE-C3-A1T"/>';
+
+const String _iOSLaunchImageVerticalTopConstraint =
+    '<constraint firstItem="YRO-k0-Ey4" firstAttribute="top" secondItem="Ze5-6b-2t3" secondAttribute="top" id="xPn-NY-SIU"/>';
+
+const String _iOSLaunchImageVerticalCenterConstraint =
+    '<constraint firstItem="YRO-k0-Ey4" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="4X2-HB-R7a"/>';
+
+const String _iOSLaunchImageVerticalBottomConstraint =
+    '<constraint firstAttribute="bottom" secondItem="YRO-k0-Ey4" secondAttribute="bottom" id="duK-uY-Gun"/>';
+
 const String _iOSBrandingCenterBottomConstraints = '''
 <constraints>
   <constraint firstItem="Uyq-Kz-ftE" firstAttribute="centerX" secondItem="YRO-k0-Ey4" secondAttribute="centerX" id="3kg-TC-cPP"/>


### PR DESCRIPTION
I added this to provide iOS behavior similar to Android’s android_gravity option, by introducing anchored ios_content_mode syntax (scaleAspectFit|<anchor>, scaleAspectFill|<anchor>).
I also verified the behavior using the example project across base and anchored placements.
I’d appreciate your review.